### PR TITLE
project: support ET_DYN ELF kernel and FDT bootargs

### DIFF
--- a/hw/core/src/loader.rs
+++ b/hw/core/src/loader.rs
@@ -9,6 +9,8 @@ pub struct LoadInfo {
     pub entry: GPA,
     /// Total bytes loaded.
     pub size: u64,
+    /// Load bias applied for ET_DYN images (None for ET_EXEC).
+    pub bias: Option<u64>,
 }
 
 /// Load a raw binary image at the given guest physical address.
@@ -21,6 +23,7 @@ pub fn load_binary(
     Ok(LoadInfo {
         entry: addr,
         size: data.len() as u64,
+        bias: None,
     })
 }
 
@@ -48,6 +51,7 @@ fn write_bytes(as_: &AddressSpace, base: GPA, data: &[u8]) {
 const EI_MAG: [u8; 4] = [0x7f, b'E', b'L', b'F'];
 const ELFCLASS64: u8 = 2;
 const ET_EXEC: u16 = 2;
+const ET_DYN: u16 = 3;
 const PT_LOAD: u32 = 1;
 const SHT_SYMTAB: u32 = 2;
 
@@ -56,45 +60,74 @@ const ELF64_PHDR_SIZE: usize = 56;
 const ELF64_SHDR_SIZE: usize = 64;
 const ELF64_SYM_SIZE: usize = 24;
 
-/// Load an ELF-64 binary into the address space and return
-/// the entry point.
-///
-/// Only `PT_LOAD` segments are processed.  The binary must
-/// be a little-endian ELF-64 executable (e.g. RISC-V).
-pub fn load_elf(data: &[u8], as_: &AddressSpace) -> Result<LoadInfo, String> {
+struct ElfHeader {
+    e_type: u16,
+    e_entry: u64,
+    e_phoff: usize,
+    e_phentsize: usize,
+    e_phnum: usize,
+}
+
+fn parse_elf_header(data: &[u8]) -> Result<ElfHeader, String> {
     if data.len() < ELF64_EHDR_SIZE {
         return Err("data too small for ELF header".into());
     }
-
-    // e_ident[0..4] = magic
     if data[0..4] != EI_MAG {
         return Err("bad ELF magic".into());
     }
-    // EI_CLASS
     if data[4] != ELFCLASS64 {
         return Err("not ELF-64".into());
     }
 
     let e_type = u16::from_le_bytes(data[16..18].try_into().unwrap());
-    if e_type != ET_EXEC {
-        return Err(format!("unsupported ELF type {e_type} (need ET_EXEC)"));
+    if e_type != ET_EXEC && e_type != ET_DYN {
+        return Err(format!(
+            "unsupported ELF type {e_type} \
+             (need ET_EXEC or ET_DYN)"
+        ));
     }
 
     let e_entry = u64::from_le_bytes(data[24..32].try_into().unwrap());
     let e_phoff = u64::from_le_bytes(data[32..40].try_into().unwrap()) as usize;
-    // e_shoff(40..48), e_flags(48..52), e_ehsize(52..54)
     let e_phentsize =
         u16::from_le_bytes(data[54..56].try_into().unwrap()) as usize;
     let e_phnum = u16::from_le_bytes(data[56..58].try_into().unwrap()) as usize;
 
     if e_phentsize < ELF64_PHDR_SIZE {
-        return Err(format!("phentsize {e_phentsize} < {ELF64_PHDR_SIZE}"));
+        return Err(format!(
+            "phentsize {e_phentsize} < {ELF64_PHDR_SIZE}"
+        ));
     }
+
+    Ok(ElfHeader {
+        e_type,
+        e_entry,
+        e_phoff,
+        e_phentsize,
+        e_phnum,
+    })
+}
+
+/// Load an ELF-64 binary into the address space and return
+/// the entry point.
+///
+/// For ET_EXEC segments are loaded at their `p_paddr`.
+/// For ET_DYN (PIE) segments are loaded relative to
+/// `base_addr`.  The `LoadInfo.bias` field carries the
+/// offset so the caller can relocate the entry address.
+pub fn load_elf(
+    data: &[u8],
+    base_addr: u64,
+    as_: &AddressSpace,
+) -> Result<LoadInfo, String> {
+    let hdr = parse_elf_header(data)?;
+
+    let is_dyn = hdr.e_type == ET_DYN;
 
     let mut total_loaded: u64 = 0;
 
-    for i in 0..e_phnum {
-        let off = e_phoff + i * e_phentsize;
+    for i in 0..hdr.e_phnum {
+        let off = hdr.e_phoff + i * hdr.e_phentsize;
         if off + ELF64_PHDR_SIZE > data.len() {
             return Err("phdr out of bounds".into());
         }
@@ -107,6 +140,8 @@ pub fn load_elf(data: &[u8], as_: &AddressSpace) -> Result<LoadInfo, String> {
         let p_offset =
             u64::from_le_bytes(data[off + 8..off + 16].try_into().unwrap())
                 as usize;
+        let p_vaddr =
+            u64::from_le_bytes(data[off + 16..off + 24].try_into().unwrap());
         let p_paddr =
             u64::from_le_bytes(data[off + 24..off + 32].try_into().unwrap());
         let p_filesz =
@@ -114,6 +149,14 @@ pub fn load_elf(data: &[u8], as_: &AddressSpace) -> Result<LoadInfo, String> {
                 as usize;
         let p_memsz =
             u64::from_le_bytes(data[off + 40..off + 48].try_into().unwrap());
+
+        // For ET_DYN: load address = base_addr + p_vaddr.
+        // For ET_EXEC: load address = p_paddr (absolute).
+        let load_addr = if is_dyn {
+            base_addr + p_vaddr
+        } else {
+            p_paddr
+        };
 
         if p_offset + p_filesz > data.len() {
             return Err(format!(
@@ -123,11 +166,11 @@ pub fn load_elf(data: &[u8], as_: &AddressSpace) -> Result<LoadInfo, String> {
         }
 
         let seg = &data[p_offset..p_offset + p_filesz];
-        write_bytes(as_, GPA::new(p_paddr), seg);
+        write_bytes(as_, GPA::new(load_addr), seg);
 
         // BSS: zero-fill [p_filesz .. p_memsz)
-        let bss_start = p_paddr + p_filesz as u64;
-        let bss_end = p_paddr + p_memsz;
+        let bss_start = load_addr + p_filesz as u64;
+        let bss_end = load_addr + p_memsz;
         let mut cur = bss_start;
         while cur < bss_end {
             let remain = bss_end - cur;
@@ -143,9 +186,19 @@ pub fn load_elf(data: &[u8], as_: &AddressSpace) -> Result<LoadInfo, String> {
         total_loaded += p_memsz;
     }
 
+    // For ET_DYN the actual entry = base_addr + e_entry.
+    let entry = if is_dyn {
+        base_addr + hdr.e_entry
+    } else {
+        hdr.e_entry
+    };
+
+    let bias = if is_dyn { Some(base_addr) } else { None };
+
     Ok(LoadInfo {
-        entry: GPA::new(e_entry),
+        entry: GPA::new(entry),
         size: total_loaded,
+        bias,
     })
 }
 

--- a/hw/riscv/src/boot.rs
+++ b/hw/riscv/src/boot.rs
@@ -208,7 +208,7 @@ pub fn boot_ref_machine(
             let data = std::fs::read(path)?;
             let as_ = machine.address_space();
             if is_elf(&data) {
-                let info = loader::load_elf(&data, as_)
+                let info = loader::load_elf(&data, RAM_BASE, as_)
                     .map_err(|e| -> Box<dyn std::error::Error> { e.into() })?;
                 fw_entry = Some(info.entry.0);
             } else {
@@ -225,9 +225,10 @@ pub fn boot_ref_machine(
                 let data = std::fs::read(&path)?;
                 let as_ = machine.address_space();
                 if is_elf(&data) {
-                    let info = loader::load_elf(&data, as_).map_err(
-                        |e| -> Box<dyn std::error::Error> { e.into() },
-                    )?;
+                    let info = loader::load_elf(&data, RAM_BASE, as_)
+                        .map_err(|e| -> Box<dyn std::error::Error> {
+                            e.into()
+                        })?;
                     fw_entry = Some(info.entry.0);
                 } else {
                     loader::load_binary(&data, GPA::new(RAM_BASE), as_)
@@ -247,7 +248,7 @@ pub fn boot_ref_machine(
     }
 
     // Load kernel.
-    let mut kernel_entry: Option<u64> = None;
+    let mut dinfo_next: Option<u64> = None;
     if let Some(ref kernel_path) = machine.kernel_path {
         let data = std::fs::read(kernel_path)?;
         let as_ = machine.address_space();
@@ -257,14 +258,15 @@ pub fn boot_ref_machine(
             RAM_BASE
         };
         if is_elf(&data) {
-            let info = loader::load_elf(&data, as_)
+            let info = loader::load_elf(&data, load_addr, as_)
                 .map_err(|e| -> Box<dyn std::error::Error> { e.into() })?;
-            kernel_entry = Some(info.entry.0);
+            dinfo_next = Some(info.entry.0);
         } else {
             loader::load_binary(&data, GPA::new(load_addr), as_)
                 .map_err(|e| -> Box<dyn std::error::Error> { e.into() })?;
         }
     }
+    let kernel_entry = dinfo_next;
 
     // Load initrd (if provided) after the kernel.
     let mut initrd_range: Option<(u64, u64)> = None;
@@ -307,24 +309,14 @@ pub fn boot_ref_machine(
     } else if let Some(entry) = kernel_entry {
         entry
     } else if machine.kernel_path.is_some() {
-        if has_firmware {
-            RAM_BASE + KERNEL_OFFSET
-        } else {
-            RAM_BASE
-        }
+        RAM_BASE + KERNEL_OFFSET
     } else {
         RAM_BASE
     };
 
-    // Compute kernel_entry for fw_dynamic_info.next_addr.
-    let dinfo_next = if has_firmware {
-        kernel_entry.unwrap_or(RAM_BASE + KERNEL_OFFSET)
-    } else {
-        start_addr
-    };
-
     // Write MROM: reset vector + fw_dynamic_info.
-    write_mrom(machine, start_addr, fdt_addr, dinfo_next, has_firmware);
+    let dinfo_final = kernel_entry.unwrap_or(RAM_BASE + KERNEL_OFFSET);
+    write_mrom(machine, start_addr, fdt_addr, dinfo_final, has_firmware);
 
     // CPU0 starts at MROM base in M-mode.
     {

--- a/hw/riscv/src/boot.rs
+++ b/hw/riscv/src/boot.rs
@@ -248,7 +248,7 @@ pub fn boot_ref_machine(
     }
 
     // Load kernel.
-    let mut dinfo_next: Option<u64> = None;
+    let mut kernel_entry: Option<u64> = None;
     if let Some(ref kernel_path) = machine.kernel_path {
         let data = std::fs::read(kernel_path)?;
         let as_ = machine.address_space();
@@ -260,13 +260,13 @@ pub fn boot_ref_machine(
         if is_elf(&data) {
             let info = loader::load_elf(&data, load_addr, as_)
                 .map_err(|e| -> Box<dyn std::error::Error> { e.into() })?;
-            dinfo_next = Some(info.entry.0);
+            kernel_entry = Some(info.entry.0);
         } else {
             loader::load_binary(&data, GPA::new(load_addr), as_)
                 .map_err(|e| -> Box<dyn std::error::Error> { e.into() })?;
+            kernel_entry = Some(load_addr);
         }
     }
-    let kernel_entry = dinfo_next;
 
     // Load initrd (if provided) after the kernel.
     let mut initrd_range: Option<(u64, u64)> = None;
@@ -308,8 +308,6 @@ pub fn boot_ref_machine(
         RAM_BASE
     } else if let Some(entry) = kernel_entry {
         entry
-    } else if machine.kernel_path.is_some() {
-        RAM_BASE + KERNEL_OFFSET
     } else {
         RAM_BASE
     };

--- a/src/main.rs
+++ b/src/main.rs
@@ -30,6 +30,7 @@ fn usage() {
     eprintln!("  -bios path    BIOS/firmware binary");
     eprintln!("  -kernel path  Kernel binary");
     eprintln!("  -nographic    Disable graphical output");
+    eprintln!("  -append args  Kernel command line arguments");
     eprintln!(
         "  --difftest    Instruction-level difftest \
          vs QEMU"
@@ -50,6 +51,7 @@ struct CliArgs {
     ram_mib: u64,
     bios: Option<PathBuf>,
     kernel: Option<PathBuf>,
+    append: Option<String>,
     nographic: bool,
     difftest: bool,
     drive: Option<PathBuf>,
@@ -67,6 +69,7 @@ impl Default for CliArgs {
             ram_mib: 128,
             bios: None,
             kernel: None,
+            append: None,
             nographic: false,
             difftest: false,
             drive: None,
@@ -118,6 +121,14 @@ fn parse_args() -> Result<CliArgs, String> {
             }
             "-nographic" => {
                 cli.nographic = true;
+            }
+            "-append" => {
+                i += 1;
+                cli.append = Some(
+                    args.get(i)
+                        .ok_or("-append requires argument")?
+                        .clone(),
+                );
             }
             "--difftest" => {
                 cli.difftest = true;

--- a/src/main.rs
+++ b/src/main.rs
@@ -58,7 +58,6 @@ struct CliArgs {
     monitor: Option<String>,
     gdb: Option<String>,
     start_paused: bool,
-    append: Option<String>,
     initrd: Option<PathBuf>,
 }
 
@@ -76,7 +75,6 @@ impl Default for CliArgs {
             monitor: None,
             gdb: None,
             start_paused: false,
-            append: None,
             initrd: None,
         }
     }
@@ -152,11 +150,6 @@ fn parse_args() -> Result<CliArgs, String> {
             "-device" => {
                 // Accept and skip for QEMU compat.
                 i += 1;
-            }
-            "-append" => {
-                i += 1;
-                let s = args.get(i).ok_or("-append requires argument")?;
-                cli.append = Some(s.clone());
             }
             "-initrd" => {
                 i += 1;

--- a/tests/src/hw_loader.rs
+++ b/tests/src/hw_loader.rs
@@ -125,7 +125,7 @@ fn test_load_elf_simple() {
     // Append payload
     elf.extend_from_slice(&payload);
 
-    let info = load_elf(&elf, &as_).expect("load_elf failed");
+    let info = load_elf(&elf, 0, &as_).expect("load_elf failed");
     assert_eq!(info.entry, GPA::new(entry));
     assert_eq!(info.size, payload.len() as u64);
 
@@ -133,5 +133,59 @@ fn test_load_elf_simple() {
     for (i, &expected) in payload.iter().enumerate() {
         let actual = as_.read(GPA::new(p_paddr + i as u64), 1) as u8;
         assert_eq!(actual, expected, "mismatch at offset {i}");
+    }
+}
+
+#[test]
+fn test_load_elf_dyn_pie() {
+    // Build a minimal ELF-64 LE ET_DYN (PIE) with one
+    // PT_LOAD segment at vaddr 0x1000, then load it
+    // at base 0x100_0000 and verify relocation bias.
+    let as_ = make_ram_as(0x1000_0000);
+
+    let entry_rel: u64 = 0x1100;  // entry relative to vaddr 0
+    let p_vaddr: u64 = 0x1000;    // segment vaddr
+    let base: u64 = 0x100_0000;   // load base
+    let payload: [u8; 8] = [0x11, 0x22, 0x33, 0x44, 0x55, 0x66, 0x77, 0x88];
+
+    // -- ELF header (64 bytes) --
+    let mut elf = vec![0u8; 64 + 56];
+
+    elf[0..4].copy_from_slice(&[0x7f, b'E', b'L', b'F']);
+    elf[4] = 2;  // ELFCLASS64
+    elf[5] = 1;  // ELFDATA2LSB
+    elf[6] = 1;  // EV_CURRENT
+    // e_type = ET_DYN (3)
+    elf[16..18].copy_from_slice(&3u16.to_le_bytes());
+    elf[20..24].copy_from_slice(&1u32.to_le_bytes());
+    elf[24..32].copy_from_slice(&entry_rel.to_le_bytes());
+    elf[32..40].copy_from_slice(&64u64.to_le_bytes()); // e_phoff
+    elf[52..54].copy_from_slice(&64u16.to_le_bytes());  // e_ehsize
+    elf[54..56].copy_from_slice(&56u16.to_le_bytes());  // e_phentsize
+    elf[56..58].copy_from_slice(&1u16.to_le_bytes());   // e_phnum
+
+    // -- Program header (56 bytes at offset 64) --
+    let ph = 64usize;
+    elf[ph..ph + 4].copy_from_slice(&1u32.to_le_bytes()); // PT_LOAD
+    let p_offset: u64 = 120;
+    elf[ph + 8..ph + 16].copy_from_slice(&p_offset.to_le_bytes());
+    elf[ph + 16..ph + 24].copy_from_slice(&p_vaddr.to_le_bytes()); // p_vaddr
+    elf[ph + 24..ph + 32].copy_from_slice(&p_vaddr.to_le_bytes()); // p_paddr
+    let filesz = payload.len() as u64;
+    elf[ph + 32..ph + 40].copy_from_slice(&filesz.to_le_bytes());
+    elf[ph + 40..ph + 48].copy_from_slice(&filesz.to_le_bytes());
+
+    elf.extend_from_slice(&payload);
+
+    let info = load_elf(&elf, base, &as_).expect("load_elf ET_DYN failed");
+    let expected = base + p_vaddr;
+    assert_eq!(info.entry, GPA::new(base + entry_rel));
+    assert!(info.bias.is_some());
+    assert_eq!(info.bias.unwrap(), base);
+    assert_eq!(info.size, filesz);
+
+    for (i, &exp) in payload.iter().enumerate() {
+        let actual = as_.read(GPA::new(expected + i as u64), 1) as u8;
+        assert_eq!(actual, exp, "mismatch at offset {i}");
     }
 }


### PR DESCRIPTION
Add ET_DYN (PIE) ELF loading to the loader, needed for position- independent Linux kernels. Wire -append CLI flag through to the FDT /chosen/bootargs property for kernel command-line arguments.