### PR TITLE
github: add PR and issue templates

### DIFF
--- a/.github/ISSUE_TEMPLATE/bug_report.yml
+++ b/.github/ISSUE_TEMPLATE/bug_report.yml
@@ -1,0 +1,123 @@
+name: Bug Report
+description: Report a bug or unexpected behavior
+labels: ["bug"]
+body:
+  - type: markdown
+    attributes:
+      value: |
+        Thank you for reporting a bug. Please fill out the sections below.
+  - type: textarea
+    id: description
+    attributes:
+      label: Bug Description
+      description: A clear description of what went wrong.
+    validations:
+      required: true
+  - type: textarea
+    id: steps
+    attributes:
+      label: Steps to Reproduce
+      description: |
+        Minimal steps to trigger the bug.
+        Include the command you ran, the guest image/firmware used,
+        and any relevant configuration.
+      placeholder: |
+        1. Build with `cargo build --release`
+        2. Run `./machina run -b rcore-ch4`
+        3. ...
+    validations:
+      required: true
+  - type: textarea
+    id: expected
+    attributes:
+      label: Expected Behavior
+      description: What did you expect to happen?
+    validations:
+      required: true
+  - type: textarea
+    id: actual
+    attributes:
+      label: Actual Behavior
+      description: |
+        What happened instead?
+        Include logs, panics, or error output.
+    validations:
+      required: true
+  - type: input
+    id: version
+    attributes:
+      label: Machina Version
+      description: Commit hash or release tag.
+      placeholder: e.g. a1b2c3d or v0.3.0
+    validations:
+      required: true
+  - type: dropdown
+    id: guest
+    attributes:
+      label: Guest
+      description: Which guest OS / firmware were you running?
+      options:
+        - rCore-Tutorial (ch1–3)
+        - rCore-Tutorial (ch4, Sv39)
+        - rCore-Tutorial (ch5+, process/filesystem)
+        - Other / custom firmware
+    validations:
+      required: true
+  - type: textarea
+    id: env
+    attributes:
+      label: Host Environment
+      description: OS, CPU arch, Rust toolchain version (`rustc --version`).
+      placeholder: |
+        OS: Ubuntu 24.04, x86_64
+        rustc: 1.85.0
+  - type: textarea
+    id: fix-idea
+    attributes:
+      label: Possible Fix / Root Cause
+      description: If you have investigated, share your findings here.
+    validations:
+      required: false
+
+  # --- Agent collaboration checklist ---
+  - type: markdown
+    attributes:
+      value: |
+        ---
+
+        ## Agent Collaboration Checklist
+
+        If this issue was prepared or investigated with the help of
+        an AI agent (Claude, Codex, Cursor, etc.), please answer
+        the following.
+  - type: checkboxes
+    id: agent-docs
+    attributes:
+      label: Agent Documentation Awareness
+      options:
+        - label: >
+            I confirmed the agent has fully read the relevant
+            `docs/` content (design, coding-style, testing,
+            backend-specific docs, etc.) before preparing
+            this issue.
+          required: false
+  - type: checkboxes
+    id: agent-tests
+    attributes:
+      label: Regression Test Plan
+      options:
+        - label: >
+            I have identified or drafted a regression test
+            that reproduces this bug (describe in
+            "Possible Fix / Root Cause" above).
+          required: false
+  - type: checkboxes
+    id: agent-human-review
+    attributes:
+      label: Human Review
+      options:
+        - label: >
+            I have manually reviewed the agent's analysis
+            and confirmed the root cause and reproduction
+            steps are accurate.
+          required: false

--- a/.github/ISSUE_TEMPLATE/config.yml
+++ b/.github/ISSUE_TEMPLATE/config.yml
@@ -1,0 +1,6 @@
+blank_issues_enabled: false
+contact_links:
+  - name: Question / Discussion
+    url: https://github.com/gevico/machina/discussions
+    about: |
+      Ask a question or start a discussion about Machina.

--- a/.github/ISSUE_TEMPLATE/feature_request.yml
+++ b/.github/ISSUE_TEMPLATE/feature_request.yml
@@ -1,0 +1,101 @@
+name: Feature Request
+description: Propose a new feature or enhancement
+labels: ["enhancement"]
+body:
+  - type: markdown
+    attributes:
+      value: |
+        Thank you for your suggestion. Please fill out the sections below.
+  - type: textarea
+    id: problem
+    attributes:
+      label: Problem / Motivation
+      description: |
+        What problem does this feature solve?
+        Is your feature request related to an existing issue?
+    validations:
+      required: true
+  - type: textarea
+    id: solution
+    attributes:
+      label: Proposed Solution
+      description: |
+        Describe the desired behavior or interface.
+        Include diagrams, pseudocode, or references if helpful.
+    validations:
+      required: true
+  - type: textarea
+    id: alternatives
+    attributes:
+      label: Alternatives Considered
+      description: What other approaches have you considered?
+    validations:
+      required: false
+  - type: textarea
+    id: scope
+    attributes:
+      label: Affected Components
+      description: |
+        Which crates or subsystems does this touch?
+        (e.g. accel, memory, hw, core, decode, etc.)
+      placeholder: |
+        - accel/jit
+        - hw/riscv
+        - memory
+    validations:
+      required: true
+  - type: textarea
+    id: test-plan
+    attributes:
+      label: Test Plan
+      description: |
+        How should this feature be tested?
+        Describe expected-path, edge-case, and failure-case tests.
+      placeholder: |
+        - Unit test for new API in machina-tests
+        - Integration: boot rCore chX with new feature enabled
+        - Failure: verify graceful error when <condition>
+    validations:
+      required: false
+
+  # --- Agent collaboration checklist ---
+  - type: markdown
+    attributes:
+      value: |
+        ---
+
+        ## Agent Collaboration Checklist
+
+        If this feature request was prepared with the help of
+        an AI agent (Claude, Codex, Cursor, etc.), please answer
+        the following.
+  - type: checkboxes
+    id: agent-docs
+    attributes:
+      label: Agent Documentation Awareness
+      options:
+        - label: >
+            I confirmed the agent has fully read the relevant
+            `docs/` content (design, coding-style, testing,
+            backend-specific docs, etc.) before preparing
+            this feature request.
+          required: false
+  - type: checkboxes
+    id: agent-tests
+    attributes:
+      label: Test Coverage Plan
+      options:
+        - label: >
+            I have outlined test cases (expected path, edge cases,
+            failure cases) in the "Test Plan" section above.
+          required: false
+  - type: checkboxes
+    id: agent-human-review
+    attributes:
+      label: Human Review
+      options:
+        - label: >
+            I have manually reviewed the agent's analysis and
+            confirmed the proposed solution and scope are
+            reasonable.
+          required: false

--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -1,0 +1,53 @@
+---
+name: Pull Request
+about: Submit a change for review
+---
+
+## Summary
+
+<!-- Briefly describe what this PR does and why. -->
+
+## Type of Change
+
+- [ ] Bug fix
+- [ ] New feature
+- [ ] Refactor / cleanup
+- [ ] Documentation update
+- [ ] Test addition / update
+- [ ] CI / build change
+- [ ] Other: ___________
+
+## Changes
+
+<!-- List the key changes. Keep it concise. -->
+
+-
+
+## Test Plan
+
+<!-- How did you verify this change? -->
+
+- [ ] `make fmt-check` passes
+- [ ] `make clippy` passes
+- [ ] `make test` passes
+- [ ] New tests added for expected path, edge cases, and failure cases
+- [ ] Existing tests cover this change
+
+## Agent Collaboration Checklist
+
+*If this PR was prepared with the help of an AI agent (Claude, Codex,
+Cursor, etc.), please confirm the following.*
+
+- [ ] **Docs read**: I confirmed the agent has fully read the relevant
+      `docs/` content (design, coding-style, testing, backend-specific
+      docs, etc.) before preparing this PR.
+- [ ] **Tests added**: For bug fixes and new features, corresponding
+      tests have been added or updated in the `tests/` crate
+      (`machina-tests`).
+- [ ] **Human code review**: I have manually reviewed the agent's code
+      implementation and confirmed the overall source-level correctness
+      (logic, safety, error handling).
+
+## Related Issues
+
+<!-- e.g. Closes #123, Fixes #456 -->


### PR DESCRIPTION
## Summary

- Add structured GitHub issue templates for **bug reports** and
  **feature requests** (YAML form-based)
- Add a **pull request template** with quality-gate checklist
- Add `config.yml` to disable blank issues and redirect to
  Discussions

## Agent Collaboration Checklist

Each template includes an **Agent Collaboration Checklist** section
that asks contributors to confirm:

1. **Docs read** — the AI agent has fully read the relevant `docs/`
   content (design, coding-style, testing, backend-specific docs,
   etc.) before preparing the issue/PR
2. **Tests added** — for features and bug fixes, corresponding tests
   have been added or updated in the `tests/` crate (`machina-tests`)
3. **Human code review** — a human has manually reviewed the agent's
   code/analysis and confirmed the overall correctness of the
   implementation

## Files Added

| File | Purpose |
|------|---------|
| `.github/ISSUE_TEMPLATE/bug_report.yml` | Bug report form |
| `.github/ISSUE_TEMPLATE/feature_request.yml` | Feature request form |
| `.github/ISSUE_TEMPLATE/config.yml` | Disable blank issues |
| `.github/PULL_REQUEST_TEMPLATE.md` | Pull request template |

## Test Plan

- [x] YAML syntax is valid (GitHub Forms schema)
- [x] Templates render correctly on GitHub
- [x] `config.yml` blocks blank issues and links to Discussions