### PR TITLE
project: add Makefile, CI integration, guidelines, and toolchain config

### DIFF
--- a/.github/workflows/check.yml
+++ b/.github/workflows/check.yml
@@ -14,5 +14,11 @@ jobs:
       - name: Install Rust
         uses: dtolnay/rust-toolchain@stable
 
+      - name: Cache Cargo
+        uses: Swatinem/rust-cache@v2
+
       - name: Check code formatting
-        run: cargo fmt --all --check
+        run: make fmt-check
+
+      - name: Run Clippy
+        run: make clippy

--- a/.github/workflows/docs.yml
+++ b/.github/workflows/docs.yml
@@ -1,4 +1,4 @@
-name: machina-tests
+name: docs
 
 on:
   push:
@@ -6,9 +6,8 @@ on:
   workflow_dispatch:
 
 jobs:
-  test:
+  build-docs:
     runs-on: ubuntu-latest
-    timeout-minutes: 90
     env:
       CARGO_TERM_COLOR: always
     steps:
@@ -21,13 +20,11 @@ jobs:
       - name: Cache Cargo
         uses: Swatinem/rust-cache@v2
 
-      - name: Install test dependencies
-        run: |
-          sudo apt-get update
-          sudo apt-get install -y \
-            build-essential \
-            gcc-riscv64-linux-gnu \
-            qemu-user
+      - name: Build documentation
+        run: make docs
 
-      - name: Run all tests
-        run: make test
+      - name: Upload docs artifact
+        uses: actions/upload-artifact@v4
+        with:
+          name: rustdocs
+          path: target/doc

--- a/.rustfmt.toml
+++ b/.rustfmt.toml
@@ -1,1 +1,2 @@
 max_width = 80
+reorder_imports = true

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -1,3 +1,1 @@
-# AGENTS.md
-
-See [CLAUDE.md](CLAUDE.md) for all rules and guidelines.
+CLAUDE.md

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -1,1 +1,3 @@
-CLAUDE.md
+# AGENTS.md
+
+See [CLAUDE.md](CLAUDE.md) for all rules and guidelines.

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -1,248 +1,98 @@
 # CLAUDE.md
 
-本文件为 Claude Code (claude.ai/code) 在本仓库中工作时提供指导。
+This file defines how Claude Code should work in this repository.
 
-## 项目概述
+## Core Principle
 
-Machina 是一个用 Rust 编写的模块化 RISC-V 模拟器，基于 JIT 动态二进制翻译引擎。JIT 核心源自对 QEMU TCG（Tiny Code Generator）的重新实现，参考实现位于 `~/qemu/tcg/`、`~/qemu/accel/tcg/`、`~/qemu/include/tcg/` 和 `~/qemu/hw/`。
+- Follow a spec-first workflow for any non-trivial feature, behavior change,
+  or refactor.
+- Treat the spec as the contract. Implementation may vary, but externally
+  visible behavior must match the spec.
+- Prefer correctness, reproducibility, and narrow changes over speed or
+  novelty.
 
-**当前状态快照（2026-04-02）**：
+## Before Writing Code
 
-- **JIT 引擎**：完整翻译流水线可用——RISC-V 解码、IR 生成、优化、
-  寄存器分配、x86-64 代码生成。多线程 vCPU 并发执行、直接 TB 链路、
-  MMIO helper 分发均已就绪。
-- **Full-system 模式**：RISC-V 参考机器（riscv64-ref）可引导，
-  集成 PLIC、ACLINT、UART、Sv39 MMU、SBI 固件接口。
-- **VirtIO 块设备**：VirtIO MMIO v2 transport + raw file mmap 后端，
-  支持 rCore ch6-ch8 文件系统启动。
-- **Monitor 控制台**：MMP（QMP 兼容 JSON over TCP）+ HMP 文本命令 +
-  Ctrl+A C 切换 + vCPU 暂停/恢复。
-- **Difftest**：通过 GDB RSP 协议与 QEMU 逐指令对比。
-- **RISC-V 前端**：188 条指令（RV64GC + 特权指令），含 Sv39 MMU、
-  TLB、PMP、M/S/U 特权级。
-- **测试**：1039 个测试覆盖全流水线。
-- **rCore 支持**：ch1-ch8 全部通过。
+- Read the relevant code and tests first. Do not guess hidden invariants.
+- If the request changes behavior in a meaningful way, work from a written
+  spec before editing code.
+- If no spec exists for non-trivial work, draft a minimal one or ask for one
+  before implementation.
+- A useful spec should define the goal, interface, expected behavior, edge
+  cases, failure handling, and a concrete test plan.
+- When matching external behavior, verify against the authoritative upstream
+  source and record that reference in the spec or change notes.
 
-## 构建与开发命令
+## Change Scope
 
-```bash
-cargo build                          # 构建所有 crate
-cargo build --release                # Release 构建
-cargo test --workspace               # 运行所有测试
-cargo test -p machina-core           # 测试单个 crate
-cargo test -- test_name              # 运行指定测试
-cargo clippy -- -D warnings          # Lint 检查
-cargo fmt --check                    # 格式检查
-cargo fmt                            # 自动格式化
-cargo doc --open                     # 生成并打开文档
-```
+- Keep the change boundary as small as possible.
+- Do not perform opportunistic refactors unless they are required for
+  correctness, safety, or testability.
+- Prefer removing dead or obsolete code over preserving unused paths.
+- Follow existing local patterns unless the spec requires a deliberate change.
 
-## Git Commit 规范
+## Implementation Rules
 
-Commit message 必须使用英文编写。格式如下：
+- Prefer simple, explicit code over clever abstractions.
+- New `unsafe` requires a short justification comment and must remain narrowly
+  scoped.
+- Do not hide missing functionality behind silent success, early exits, or
+  vague fallback behavior.
+- Unimplemented behavior must fail explicitly so tests can detect it.
+- Do not treat `skip`, `not handled`, or `not reached` as `pass`.
+- Keep comments sparse and in English. Explain only non-obvious logic.
 
-```
-module: subject
+## Testing Rules
 
-具体修改内容的详细说明。
+- Tests are the primary quality gate. Human review is useful, but it is not
+  the main proof of correctness.
+- Every bug fix must add or update a regression test.
+- Every new feature must include tests for the expected path, edge cases, and
+  failure cases defined by the spec.
+- Run the narrowest useful tests while iterating, then run the relevant full
+  validation before finishing.
+- A change is not done if tests fail, are silently skipped, or do not check the
+  claimed behavior.
+- Keep formatting clean and keep `cargo clippy -- -D warnings` passing for the
+  touched code.
 
-Signed-off-by: Name <email>
-```
+## Documentation Rules
 
-**Subject 行规则**：
+- Update the spec whenever behavior, interfaces, or assumptions change.
+- Update documentation when a change affects workflow, semantics, or
+  verification.
+- Keep this file focused on behavioral rules for future work.
+- Do not turn this file into a project tour, directory listing, or code-level
+  reference.
 
-- 格式为 `module: subject`，其中 `module` 是受影响的主要模块名
-- 常用 module 名：`core`、`accel`、`guest/riscv`、`decode`、`system`、`memory`、`hw/core`、`hw/intc`、`hw/char`、`hw/riscv`、`tests`、`docs`、`project`（跨模块变更）
-- subject 使用小写开头，祈使语气（如 `add`、`fix`、`remove`），不加句号
-- 总长度不超过 72 字符
+## Communication Rules
 
-**Body 规则**：
+- State assumptions, risks, and verification results clearly.
+- Ask focused questions when ambiguity would change behavior in a meaningful
+  way.
+- Surface conflicts between the request and the spec before implementing.
+- When trade-offs exist, prefer the option that is easier to test and review.
 
-- 与 subject 之间空一行
-- 说明本次变更的内容和原因（what & why），而非如何实现（how）
-- 每行不超过 80 字符
+## Review Exceptions
 
-**示例**：
+- Security-sensitive code still requires human review.
+- Complex concurrency changes still require human review.
+- `unsafe`-heavy design changes still require human review.
+- In these cases, tests are necessary but not sufficient.
 
-```
-core: add vector opcode support
+## Definition of Done
 
-Add V64/V128/V256 vector opcodes to the unified opcode enum.
-Each vector op carries OpFlags::VECTOR for backend dispatch.
+- The implementation matches the current spec.
+- Relevant tests are present and passing.
+- Failure modes are explicit and observable.
+- New `unsafe` is justified and minimal.
+- Documentation is updated where needed.
 
-Signed-off-by: Chao Liu <chao.liu.zevorn@gmail.com>
-```
+## Commit Rules
 
-## 架构
-
-### 翻译流水线
-
-```
-+-----------+   +----------+   +----------+   +-----------+   +----------+
-|   Guest   |-->| Frontend |-->| IR Build |-->| Optimizer |-->| Backend  |
-|   Binary  |   | (decode, |   | (gen_*)  |   |           |   | (x86-64) |
-|   (RV64)  |   |  trans_*)|   +----------+   +-----------+   +-----+----+
-+-----------+   +----------+                                        |
-                                                                    v
-                        +----------------------------------------------+
-                        |               Execution Engine               |
-                        |  TB Cache + Multi-vCPU + Chaining + MMIO     |
-                        +----------------------+-----------------------+
-                                               |
-                                               v
-                        +----------------------------------------------+
-                        |            Full-System Emulation             |
-                        |  riscv64-ref: PLIC + ACLINT + UART + FDT     |
-                        |  Sv39 MMU + SBI Firmware Interface           |
-                        +----------------------------------------------+
-```
-
-### Workspace 结构
-
-| Crate | 路径 | 职责 | QEMU 参考 |
-|-------|------|------|----------|
-| `machina` | `src/` | CLI 入口 | `softmmu/main.c` |
-| `machina-core` | `core/` | IR 定义、CPU trait、地址类型 | `include/tcg/tcg.h`、`tcg/tcg-opc.h` |
-| `machina-accel` | `accel/` | IR 优化、寄存器分配、x86-64 codegen、执行引擎 | `tcg/tcg.c`、`tcg/optimize.c`、`tcg/i386/`、`accel/tcg/cpu-exec.c` |
-| `machina-guest-riscv` | `guest/riscv/` | RISC-V 前端：RV64GC + 特权 ISA、Sv39 MMU | `target/riscv/translate.c` |
-| `machina-decode` | `decode/` | `.decode` 解析器与 Rust 解码器生成器 | `scripts/decodetree.py` |
-| `machina-system` | `system/` | 全系统 CPU 桥接、CpuManager、WFI | `softmmu/cpus.c` |
-| `machina-memory` | `memory/` | AddressSpace、MMIO 分发、RAM 块 | `softmmu/memory.c` |
-| `machina-hw-core` | `hw/core/` | 设备基础设施：qdev、IRQ、chardev、FDT | `hw/core/` |
-| `machina-hw-intc` | `hw/intc/` | PLIC、ACLINT（MTIMER + MSWI） | `hw/intc/` |
-| `machina-hw-char` | `hw/char/` | UART 16550A | `hw/char/` |
-| `machina-hw-riscv` | `hw/riscv/` | RISC-V 参考机器、boot、SBI | `hw/riscv/` |
-| `machina-disas` | `disas/` | RISC-V 反汇编器 | `disas/` |
-| `machina-hw-virtio` | `hw/virtio/` | VirtIO MMIO + block device | `hw/virtio/` |
-| `machina-monitor` | `monitor/` | MMP/HMP monitor 控制台 | `monitor/` |
-| `machina-difftest` | `tools/difftest/` | GDB RSP difftest 客户端 | — |
-| `machina-util` | `util/` | 共享工具 | `util/` |
-| `machina-tests` | `tests/` | 1039 个测试 | `tests/tcg/` |
-| `machina-mtest` | `tests/mtest/` | 机器级测试 | — |
-
-### 核心数据结构（C → Rust 映射）
-
-| QEMU C 结构 | Rust 等价物 | 用途 |
-|-------------|------------|------|
-| `TCGOpcode`（DEF 宏枚举） | `enum Opcode` | 158 个统一多态 IR opcodes |
-| `TCGType` | `enum Type { I32, I64, I128, V64, V128, V256 }` | IR 值类型 |
-| `TCGTemp` | `struct Temp` | IR 变量（global、local、const、fixed-reg） |
-| `TCGTempKind` | `enum TempKind { Ebb, Tb, Global, Fixed, Const }` | 变量生命周期/作用域 |
-| `TCGOp` | `struct Op` | 单个 IR 操作（opcode + args） |
-| `TCGContext` | `struct Context` | 每线程翻译状态 |
-| `TCGLabel` | `struct Label` | TB 内的分支目标 |
-| `TranslationBlock` | `struct TranslationBlock` | 缓存的翻译代码块 |
-| `CPUJumpCache` | `struct JumpCache` | 每 CPU 直接映射 TB 缓存，4096 项 |
-| `MemoryRegion` | `struct MemoryRegion` | 层级内存区域 |
-| `AddressSpace` | `struct AddressSpace` | 地址空间与 MMIO 分发 |
-
-### 翻译块生命周期
-
-1. **查找**：PC 哈希 → jump cache（每 CPU，4096 项）→ 全局哈希表（32K 桶）
-2. **未命中 → 翻译**：前端解码客户指令 → 发射 TCG IR → 优化器运行 → 后端生成宿主代码
-3. **缓存**：插入哈希表和 jump cache
-4. **执行**：跳转到生成的宿主代码
-5. **链接**：修补 TB 间的直接跳转（`goto_tb`/`exit_tb`）
-6. **失效**：自修改代码、页面取消映射或缓存满时——解链并移除
-
-热路径优化：
-
-- `next_tb_hint`：执行循环在同一条链路上复用上一次目标 TB，减少重复查找。
-- `exit_target`：对 `TB_EXIT_NOCHAIN` 场景缓存最近目标 TB（原子读写）。
-
-### 前端 Trait 设计
-
-```rust
-trait TranslatorOps {
-    fn init(&mut self, ctx: &mut Context);
-    fn translate_insn(&mut self, ctx: &mut Context) -> TranslateResult;
-    fn tb_stop(&mut self, ctx: &mut Context);
-}
-```
-
-### 后端 Trait 设计
-
-```rust
-trait HostCodeGen {
-    fn emit_prologue(&mut self, buf: &mut CodeBuffer);
-    fn emit_epilogue(&mut self, buf: &mut CodeBuffer);
-    fn patch_jump(&mut self, buf: &mut CodeBuffer, jump_offset: usize, target_offset: usize);
-    fn epilogue_offset(&self) -> usize;
-    fn init_context(&self, ctx: &mut Context);
-}
-```
-
-### Unsafe 边界
-
-`unsafe` 仅在以下场景允许使用：
-
-- JIT 代码缓冲区分配和执行（mmap + mprotect RWX 转换）
-- 调用生成的宿主代码（从代码缓冲区进行 `fn()` 指针转换）
-- 客户内存模拟的原始指针访问（TLB 快速路径）
-- 后端代码发射器中的内联汇编
-- 与外部库的 FFI 接口
-
-所有其他代码必须是安全的 Rust。
-
-## QEMU 参考路径
-
-理解原始实现的关键源文件：
-
-- **TCG 核心**：`~/qemu/tcg/tcg.c`、`~/qemu/tcg/tcg-op.c`
-- **优化器**：`~/qemu/tcg/optimize.c`
-- **执行循环**：`~/qemu/accel/tcg/cpu-exec.c`
-- **TB 管理**：`~/qemu/accel/tcg/translate-all.c`、`~/qemu/accel/tcg/tb-maint.c`
-- **软件 TLB**：`~/qemu/accel/tcg/cputlb.c`
-- **硬件模型**：`~/qemu/hw/riscv/`、`~/qemu/hw/intc/`、`~/qemu/hw/char/`
-- **后端**：`~/qemu/tcg/i386/`、`~/qemu/tcg/aarch64/`
-- **前端**：`~/qemu/target/riscv/translate.c`
-- **Decodetree**：`~/qemu/docs/devel/decodetree.rst`
-
-## 调试手段
-
-- `cargo test -p machina-tests exec::mttcg -- --nocapture`：
-  优先复现并发相关问题。
-- `RUST_BACKTRACE=1 cargo test -- --nocapture`：
-  复现并定位 guest 执行崩溃。
-
-## 代码风格
-
-代码行宽不超过 **80 列**（`.md` 文档文件不受此限制）。详细规范见 [`docs/zh/coding-style.md`](docs/zh/coding-style.md)。
-
-核心规则：
-
-- 缩进使用 4 个空格，禁止 Tab
-- 代码行宽上限 80 列，代码注释同样遵守；`.md` 文档文件不限列宽
-- 运行 `cargo fmt` 格式化，`cargo clippy -- -D warnings` 零警告
-- 注释使用英文，仅在关键逻辑处添加
-- 常量命名：QEMU 风格的操作码常量允许 `non_upper_case_globals`
-- `unsafe` 仅限 JIT 执行和客户内存访问
-- **测试集中管理**：所有测试**必须**写在 `tests/` crate（`machina-tests`）中，**禁止**在各 crate 内部的 `tests/` 目录或 `#[cfg(test)] mod tests` 中编写测试。各 crate 仅提供 `pub` 接口供 tests crate 调用。
-
-## ASCII 图表规范
-
-文档中的所有架构图、流程图、框图必须遵循以下规则：
-
-- **仅使用 ASCII 字符**：框线使用 `+`、`-`、`|`，箭头使用 `-->`、`|`、`v`。禁止 Unicode 框线字符（`┌─┐│└┘├┤`）和 Unicode 箭头（`→←↑↓▼▲`）
-- **框线必须严格对齐**：同一个 box 的 `+` 角点、`-` 横线、`|` 竖线必须在相同列/行上。内容行的左 `|` 和右 `|` 必须与顶部/底部的 `+` 在完全相同的列
-- **框内内容定宽**：每个 box 内所有内容行长度必须一致（等于顶部 `-` 的数量），不足用空格填充到右 `|` 之前
-- **流程图内部使用英文**：框内标签、流向描述统一使用英文
-- **编写后验证**：新建或修改图表后，用 `awk` 或脚本检查所有 `|` 和 `+` 的列号是否一致
-
-示例（正确对齐）：
-
-```
-+----------+   +-----------+   +----------+
-|  Input   |-->| Transform |-->|  Output  |
-| (source) |   |           |   | (target) |
-+----------+   +-----------+   +----------+
-```
-
-## 设计原则
-
-- **不向后兼容**：自由破坏、积极清理，不做迁移垫片。
-- **基于 Trait 的可扩展性**：前端和后端是 trait 实现，而非条件编译。
-- **枚举驱动的 Opcodes**：用带 `#[repr(u8)]` 的 Rust 枚举替代 C 的 `DEF()` 宏模式。
-- **类型安全的 IR 构建器**：利用 Rust 类型系统在编译期防止混用 I32/I64 操作数。
-- **QEMU 兼容设备模型**：qdev 层级、IRQ sink、FDT 生成、chardev 抽象。
-- **最小化 `unsafe`**：限制在 JIT 执行和客户内存访问中；其他一切使用安全 Rust。
+- Use English commit messages.
+- Format the subject as `module: subject`.
+- Keep the subject within 72 characters.
+- Use the body for what changed and why, not a code walkthrough.
+- For commits created in this repository, add a `Signed-off-by` line that
+  matches the current `git config user.name` and `git config user.email`.

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -1,98 +1,111 @@
 # CLAUDE.md
 
-This file defines how Claude Code should work in this repository.
+This file is the authoritative source of rules for all AI agents and human
+contributors working in this repository. Tool-specific files (e.g. AGENTS.md)
+point here and add only tool-specific context on top.
 
-## Core Principle
+Detailed coding guidelines live under `docs/en/` (English) and `docs/zh/`
+(Chinese). When in doubt, this file takes precedence.
 
-- Follow a spec-first workflow for any non-trivial feature, behavior change,
-  or refactor.
-- Treat the spec as the contract. Implementation may vary, but externally
-  visible behavior must match the spec.
-- Prefer correctness, reproducibility, and narrow changes over speed or
-  novelty.
+## Project Overview
 
-## Before Writing Code
+Machina is a modular RISC-V full-system emulator written in Rust, featuring a
+JIT dynamic binary translation engine. It reimplements core QEMU concepts
+(TCG, device models, full-system emulation) to boot rCore-Tutorial ch1-ch8.
 
-- Read the relevant code and tests first. Do not guess hidden invariants.
-- If the request changes behavior in a meaningful way, work from a written
-  spec before editing code.
-- If no spec exists for non-trivial work, draft a minimal one or ask for one
-  before implementation.
-- A useful spec should define the goal, interface, expected behavior, edge
-  cases, failure handling, and a concrete test plan.
-- When matching external behavior, verify against the authoritative upstream
-  source and record that reference in the spec or change notes.
+## Quick Start
 
-## Change Scope
+```bash
+make build          # build all crates (debug)
+make release        # build all crates (release)
+make test           # run all tests
+make clippy         # lint with -D warnings
+make fmt            # auto-format
+make fmt-check      # check formatting
+make docs           # generate rustdocs
+make clean          # clean build artifacts
+```
 
-- Keep the change boundary as small as possible.
-- Do not perform opportunistic refactors unless they are required for
-  correctness, safety, or testability.
-- Prefer removing dead or obsolete code over preserving unused paths.
-- Follow existing local patterns unless the spec requires a deliberate change.
+See the `Makefile` for the full list of targets.
 
-## Implementation Rules
+## Boundary Constraints
 
-- Prefer simple, explicit code over clever abstractions.
-- New `unsafe` requires a short justification comment and must remain narrowly
-  scoped.
-- Do not hide missing functionality behind silent success, early exits, or
-  vague fallback behavior.
-- Unimplemented behavior must fail explicitly so tests can detect it.
-- Do not treat `skip`, `not handled`, or `not reached` as `pass`.
-- Keep comments sparse and in English. Explain only non-obvious logic.
+### Unsafe Rust
 
-## Testing Rules
+`unsafe` is only permitted in these scenarios:
 
-- Tests are the primary quality gate. Human review is useful, but it is not
-  the main proof of correctness.
-- Every bug fix must add or update a regression test.
-- Every new feature must include tests for the expected path, edge cases, and
-  failure cases defined by the spec.
-- Run the narrowest useful tests while iterating, then run the relevant full
-  validation before finishing.
-- A change is not done if tests fail, are silently skipped, or do not check the
-  claimed behavior.
-- Keep formatting clean and keep `cargo clippy -- -D warnings` passing for the
-  touched code.
+- JIT code buffer allocation and execution (mmap + mprotect RWX)
+- Calling generated host code (function pointer cast from code buffer)
+- Raw pointer access for guest memory emulation (TLB fast path)
+- Inline assembly in the backend code emitter
+- FFI interfaces to external libraries
 
-## Documentation Rules
+Everything else must be safe Rust. Every `unsafe` block requires a short
+justification comment and must remain narrowly scoped.
 
-- Update the spec whenever behavior, interfaces, or assumptions change.
-- Update documentation when a change affects workflow, semantics, or
-  verification.
-- Keep this file focused on behavioral rules for future work.
-- Do not turn this file into a project tour, directory listing, or code-level
-  reference.
+### Test Centralization
 
-## Communication Rules
+All tests **must** live in the `tests/` crate (`machina-tests`). Do not add
+tests in individual crate `#[cfg(test)] mod tests` blocks or per-crate
+`tests/` directories. Individual crates expose `pub` interfaces for the test
+crate to call.
 
-- State assumptions, risks, and verification results clearly.
-- Ask focused questions when ambiguity would change behavior in a meaningful
-  way.
-- Surface conflicts between the request and the spec before implementing.
-- When trade-offs exist, prefer the option that is easier to test and review.
+### Code Style
 
-## Review Exceptions
+- 80-column line width for all code and code comments
+- 4-space indentation, no tabs
+- `cargo fmt` before committing
+- `cargo clippy -- -D warnings` must pass with zero warnings
+- English comments only, and only at key logic points
 
-- Security-sensitive code still requires human review.
-- Complex concurrency changes still require human review.
-- `unsafe`-heavy design changes still require human review.
-- In these cases, tests are necessary but not sufficient.
-
-## Definition of Done
-
-- The implementation matches the current spec.
-- Relevant tests are present and passing.
-- Failure modes are explicit and observable.
-- New `unsafe` is justified and minimal.
-- Documentation is updated where needed.
+Full style guide: `docs/en/coding-style.md` / `docs/zh/coding-style.md`
 
 ## Commit Rules
 
-- Use English commit messages.
-- Format the subject as `module: subject`.
-- Keep the subject within 72 characters.
-- Use the body for what changed and why, not a code walkthrough.
-- For commits created in this repository, add a `Signed-off-by` line that
-  matches the current `git config user.name` and `git config user.email`.
+- English commit messages
+- Format: `module: subject` (imperative mood, <= 72 characters)
+- Body: describe what changed and why, <= 80 characters per line
+- Add `Signed-off-by: Name <email>` for commits in this repository
+- No AI-related sign-off lines (e.g. `Co-Authored-By: Claude`)
+
+Full git guidelines: `docs/en/git-guidelines.md` / `docs/zh/git-guidelines.md`
+
+## Testing Rules
+
+- Every bug fix must add or update a regression test
+- Every new feature must include tests for expected path, edge cases, and
+  failure cases
+- A change is not done if tests fail, are silently skipped, or do not check
+  the claimed behavior
+- Run the narrowest useful tests while iterating, then full validation before
+  finishing
+
+Full testing guide: `docs/en/testing.md` / `docs/zh/testing.md`
+
+## Documentation
+
+When behavior, interfaces, or assumptions change, update the corresponding
+docs under `docs/`. Existing documentation:
+
+| File | Content |
+|------|---------|
+| `coding-style.md` | Line width, formatting, naming conventions |
+| `coding-guidelines.md` | General coding guidelines |
+| `rust-guidelines.md` | Rust-specific guidelines |
+| `git-guidelines.md` | Git commit and PR conventions |
+| `testing.md` | Test organization and policies |
+| `design.md` | Architecture and design docs |
+| `ir-ops.md` | IR opcode reference |
+| `x86_64-backend.md` | x86-64 code generation docs |
+| `linux-boot.md` | Linux boot guide |
+| `mom.md` | Memory management docs |
+| `performance.md` | Performance analysis |
+
+## Quality Gates
+
+Before submitting any change:
+
+1. `make fmt-check` passes
+2. `make clippy` passes
+3. `make test` passes
+4. Relevant documentation is updated

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -90,3 +90,11 @@ machina-monitor  = { workspace = true }
 machina-hw-core  = { workspace = true }
 machina-gdbstub  = { workspace = true }
 libc             = { workspace = true }
+
+[workspace.lints.clippy]
+all      = { level = "warn", priority = -1 }
+pedantic = { level = "warn", priority = -1 }
+nursery  = { level = "warn", priority = -1 }
+
+[lints]
+workspace = true

--- a/Makefile
+++ b/Makefile
@@ -21,7 +21,8 @@ test-frontend:
 	cargo test -p machina-tests frontend
 
 test-integration:
-	cargo test -p machina-tests integration exec
+	cargo test -p machina-tests integration
+	cargo test -p machina-tests exec
 
 clippy:
 	cargo clippy --workspace -- -D warnings -A clippy::pedantic -A clippy::nursery

--- a/Makefile
+++ b/Makefile
@@ -1,0 +1,39 @@
+SHELL := /bin/bash
+
+.PHONY: all build release test test-backend test-frontend test-integration \
+        clippy fmt fmt-check docs clean
+
+all: build
+
+build:
+	cargo build --workspace
+
+release:
+	cargo build --workspace --release
+
+test:
+	cargo test --workspace
+
+test-backend:
+	cargo test -p machina-tests backend
+
+test-frontend:
+	cargo test -p machina-tests frontend
+
+test-integration:
+	cargo test -p machina-tests integration exec
+
+clippy:
+	cargo clippy --workspace -- -D warnings -A clippy::pedantic -A clippy::nursery
+
+fmt:
+	cargo fmt --all
+
+fmt-check:
+	cargo fmt --all --check
+
+docs:
+	cargo doc --workspace
+
+clean:
+	cargo clean

--- a/accel/Cargo.toml
+++ b/accel/Cargo.toml
@@ -13,3 +13,6 @@ categories = ["emulators"]
 machina-core = { workspace = true }
 machina-memory = { workspace = true }
 libc = { workspace = true }
+
+[lints]
+workspace = true

--- a/core/Cargo.toml
+++ b/core/Cargo.toml
@@ -11,3 +11,6 @@ categories = ["emulators"]
 
 [dependencies]
 parking_lot = { workspace = true }
+
+[lints]
+workspace = true

--- a/decode/Cargo.toml
+++ b/decode/Cargo.toml
@@ -8,3 +8,6 @@ repository.workspace = true
 authors.workspace = true
 keywords = ["riscv", "decoder", "code-generation"]
 categories = ["emulators", "development-tools"]
+
+[lints]
+workspace = true

--- a/disas/Cargo.toml
+++ b/disas/Cargo.toml
@@ -8,3 +8,6 @@ repository.workspace = true
 authors.workspace = true
 keywords = ["riscv", "disassembler"]
 categories = ["emulators"]
+
+[lints]
+workspace = true

--- a/docs/en/coding-guidelines.md
+++ b/docs/en/coding-guidelines.md
@@ -1,0 +1,142 @@
+# Machina Coding Guidelines
+
+General coding guidelines for the Machina project. For Rust-specific rules,
+see [Rust Guidelines](rust-guidelines.md). For formatting and naming
+conventions, see [Coding Style](coding-style.md).
+
+## Naming
+
+### Be descriptive
+
+No single-letter names or ambiguous abbreviations. Names should reveal intent.
+
+```rust
+// Bad
+let v = t.read();
+let p = addr >> 12;
+
+// Good
+let value = temp.read();
+let page_number = addr >> PAGE_SHIFT;
+```
+
+### Be accurate
+
+Names must match what the code actually does. If the name says "count", the
+value should be a count -- not an index, offset, or mask.
+
+### Encode units in names
+
+When a value carries a physical unit or scale, embed it in the name.
+
+```rust
+let timeout_ms = 5000;
+let frame_size_in_pages = 4;
+let clock_freq_hz = 12_000_000;
+```
+
+### Boolean naming
+
+Use assertion-style names for booleans: `is_*`, `has_*`, `can_*`, `should_*`.
+
+```rust
+let is_kernel_mode = mode == Prv::M;
+let has_side_effects = op.flags().contains(OpFlags::SIDE_EFFECT);
+```
+
+## Comments
+
+### Explain why, not what
+
+Comments that restate code are noise. Explain the reasoning behind non-obvious
+decisions.
+
+```rust
+// Bad: restates the code
+// Check if page is present
+if pte.flags().contains(PteFlags::V) { ... }
+
+// Good: explains the constraint
+// Sv39 spec: fetch falls through when V=0 in S-mode
+// only traps in M-mode (spec 4.3.1)
+if pte.flags().contains(PteFlags::V) { ... }
+```
+
+### Document design decisions
+
+When multiple approaches exist, record why this one was chosen. Future readers
+need to understand the trade-off, not just the outcome.
+
+### Cite specifications
+
+When implementing hardware behavior, cite the specification section.
+
+```rust
+// RISC-V Privileged Spec 4.3.1 -- PTE attribute for global mappings
+const PTE_G: u64 = 0x10;
+```
+
+## File Organization
+
+### One concept per file
+
+Split files when they grow long or mix unrelated responsibilities. A file
+named `mmu.rs` should not contain interrupt handling logic.
+
+### Organize for top-down reading
+
+Place high-level entry points first. Helper functions and internal details
+follow. A reader should understand the public API by reading the first section.
+
+### Group into logical paragraphs
+
+Within a function, group related statements together. Separate groups with a
+blank line. Each group should express one step in the algorithm.
+
+## API Design
+
+### Hide implementation details
+
+Default to the narrowest visibility. Expose only what callers need.
+
+```rust
+// Prefer
+pub(crate) fn translate_one(ctx: &mut Context) { ... }
+
+// Avoid
+pub fn translate_one(ctx: &mut Context) { ... }
+```
+
+### Validate at boundaries, trust internally
+
+Validate inputs at public API boundaries (e.g., syscall entry, device MMIO
+write). Inside the crate, trust already-validated values.
+
+### Use types to enforce invariants
+
+If a value has constraints, encode them in the type system rather than checking
+at every use site.
+
+```rust
+// Prefer: invalid states are unrepresentable
+pub struct PhysicalPage(u64);
+
+impl PhysicalPage {
+    pub fn new(frame: u64) -> Option<Self> {
+        (frame < MAX_PHYS_PAGE).then_some(PhysicalPage(frame))
+    }
+}
+
+// Avoid: raw u64 could be any value
+fn map_page(frame: u64) { ... }
+```
+
+## Error Messages
+
+Format error messages consistently. Include the operation that failed, the
+value or identifier involved, and (where applicable) the expected range.
+
+```
+"invalid PTE at {vpn}: reserved bits set"
+"out of TB cache: capacity {cap}, requested {size}"
+```

--- a/docs/en/git-guidelines.md
+++ b/docs/en/git-guidelines.md
@@ -1,0 +1,150 @@
+# Machina Git Guidelines
+
+Git commit and pull request conventions for the Machina project.
+
+## Commit Messages
+
+### Format
+
+```
+module: subject
+
+Body describing what changed and why.
+
+Signed-off-by: Name <email>
+```
+
+### Subject line
+
+- Format: `module: subject`
+- Imperative mood: `add`, `fix`, `remove` -- not `added`, `fixed`, `removed`
+- Lowercase subject, no trailing period
+- Total length at or below 72 characters
+
+### Common module prefixes
+
+| Module | Scope |
+|--------|-------|
+| `core` | IR types, opcodes, CPU trait |
+| `accel` | IR optimization, regalloc, codegen, exec engine |
+| `guest/riscv` | RISC-V frontend (decode, translate) |
+| `decode` | .decode parser and codegen |
+| `system` | CPU manager, GDB bridge, WFI |
+| `memory` | AddressSpace, MMIO, RAM blocks |
+| `hw/core` | Device infrastructure (qdev, IRQ, FDT) |
+| `hw/intc` | PLIC, ACLINT |
+| `hw/char` | UART |
+| `hw/riscv` | Reference machine, boot, SBI |
+| `hw/virtio` | VirtIO MMIO transport and devices |
+| `monitor` | QMP/HMP console |
+| `gdbstub` | GDB remote protocol |
+| `difftest` | Difftest client |
+| `tests` | Test suite |
+| `docs` | Documentation |
+| `project` | Cross-cutting changes (CI, Makefile, configs) |
+
+### Common verb prefixes
+
+| Verb | Usage |
+|------|-------|
+| `Fix` | Correct a bug |
+| `Add` | Introduce new functionality |
+| `Remove` | Delete code or features |
+| `Refactor` | Restructure without changing behavior |
+| `Rename` | Change names of files, modules, or symbols |
+| `Implement` | Add a new subsystem or feature |
+| `Enable` | Turn on a previously disabled capability |
+| `Clean up` | Minor tidying without functional change |
+| `Bump` | Update a dependency version |
+
+### Body
+
+- Separated from subject by a blank line
+- Describe what changed and why -- not how
+- Each line at or below 80 characters
+
+### Examples
+
+```
+accel: fix register clobber in div/rem helpers
+
+The x86-64 backend used RDX as a scratch register for division
+without saving the guest's original value. Add save/restore around
+the DIV instruction.
+
+Signed-off-by: Chao Liu <chao.liu.zevorn@gmail.com>
+```
+
+```
+guest/riscv: implement Zbs (single-bit operations)
+
+Add bclr, bset, binv, bext for both register and immediate forms.
+The decoder now recognizes the Zbs extension when enabled in
+misa.
+
+Signed-off-by: Chao Liu <chao.liu.zevorn@gmail.com>
+```
+
+## Atomic Commits
+
+### One commit, one logical change
+
+Each commit must do exactly one thing. Do not mix unrelated changes in a single
+commit. If you find yourself writing "and also" in the commit message, split it.
+
+### Every commit must compile and pass tests
+
+The tree must be in a working state after every commit. No broken intermediate
+states. This ensures `git bisect` always works.
+
+### Squash fixup commits before submitting
+
+When reviewing your own branch before opening a PR, squash any temporary
+commits into the commit they belong to. Temporary commits include:
+
+- Fixup commits that correct a typo or bug introduced earlier in the branch
+- Adjustment commits that tweak a previous change (e.g., renaming, reordering)
+- Any commit whose message starts with `fixup!` or `squash!`
+
+Use `git rebase -i` to fold these into the original commit. The final PR
+history should read as a clean sequence of logical changes, not a development
+journal.
+
+### Separate refactoring from features
+
+If a feature requires preparatory refactoring, put the refactoring in its own
+commit(s) before the feature commit. This makes each commit easier to review
+and bisect.
+
+## Signed-off-by
+
+All commits in this repository must include a `Signed-off-by` line:
+
+```
+Signed-off-by: Chao Liu <chao.liu.zevorn@gmail.com>
+```
+
+Do not add AI-related sign-off lines (e.g. `Co-Authored-By: Claude`).
+
+## Pull Requests
+
+### Keep PRs focused
+
+One topic per PR. A PR that mixes a bug fix, a refactoring, and a new feature
+is difficult to review.
+
+### CI must pass
+
+Ensure all CI checks pass before requesting review:
+
+- `make test` -- all tests pass
+- `make clippy` -- zero warnings
+- `make fmt-check` -- formatting is clean
+
+### Reference issues
+
+When a PR addresses an issue, reference it in the description:
+
+```
+Closes #42
+```

--- a/docs/en/rust-guidelines.md
+++ b/docs/en/rust-guidelines.md
@@ -1,0 +1,196 @@
+# Machina Rust Guidelines
+
+Rust-specific guidelines for the Machina project. For general coding rules, see
+[Coding Guidelines](coding-guidelines.md). For formatting conventions, see
+[Coding Style](coding-style.md).
+
+## Unsafe Rust
+
+### Justify every use of unsafe
+
+Every `unsafe` block requires a `// SAFETY:` comment explaining why the
+operation is sound. Every `unsafe fn` or `unsafe trait` requires a `# Safety`
+doc section describing the conditions callers must uphold.
+
+```rust
+// SAFETY: buf points to a valid, RWX-mapped region of `len` bytes.
+// The mmap call above guaranteed alignment and permissions.
+unsafe { core::ptr::copy_nonoverlapping(src.as_ptr(), buf, len) }
+```
+
+### Unsafe is confined to specific modules
+
+`unsafe` is only permitted for JIT code buffer management, function pointer
+casts for generated code, raw pointer access in the TLB fast path, inline
+assembly in the backend emitter, and FFI. All other code must be safe Rust.
+
+## Functions
+
+### Keep functions small and focused
+
+A function should do one thing. If it needs a comment to separate sections,
+consider splitting it.
+
+### Minimize nesting
+
+Target at most 3 levels of nesting. Use early returns, `let...else`, and `?`
+to flatten control flow.
+
+```rust
+// Prefer
+let Some(pte) = page_table.walk(vpn) else {
+    return Err(MmuFault::InvalidPte);
+};
+
+// Avoid
+if let Some(pte) = page_table.walk(vpn) {
+    // ... deeply nested logic ...
+}
+```
+
+### Avoid boolean parameters
+
+Use an enum or split into two functions.
+
+```rust
+// Prefer
+pub fn emit_load_signed(buf: &mut CodeBuffer, ...) { ... }
+pub fn emit_load_unsigned(buf: &mut CodeBuffer, ...) { ... }
+
+// Avoid
+pub fn emit_load(buf: &mut CodeBuffer, signed: bool, ...) { ... }
+```
+
+## Types and Traits
+
+### Prefer enums over trait objects for closed sets
+
+When the set of variants is known at compile time, use an enum. Trait objects
+(`dyn Trait`) are appropriate only for open-ended extensibility.
+
+```rust
+// Prefer
+enum Exception {
+    InstructionAccessFault,
+    LoadAccessFault,
+    StoreAccessFault,
+    // ...
+}
+
+// Avoid
+trait Exception { fn handle(&self); }
+```
+
+### Encapsulate fields behind getters
+
+Expose fields through methods rather than making them `pub`. This preserves
+the ability to add validation or logging later.
+
+## Modules and Crates
+
+### Default to narrow visibility
+
+Use `pub(super)` or `pub(crate)` by default. Only use `pub` when external
+crates genuinely need access.
+
+### Qualify function imports via parent module
+
+Import the parent module, then call the function through it. This makes the
+origin explicit.
+
+```rust
+// Prefer
+use core::mem;
+mem::replace(&mut slot, new_value)
+
+// Avoid
+use core::mem::replace;
+replace(&mut slot, new_value)
+```
+
+### Use workspace dependencies
+
+All shared dependency versions must be declared in the workspace root
+`Cargo.toml` under `[workspace.dependencies]`. Individual crates reference
+them with `{ workspace = true }`.
+
+## Error Handling
+
+### Propagate errors with `?`
+
+Do not `.unwrap()` or `.expect()` where failure is possible. Use `?` to
+propagate errors to the caller.
+
+### Define domain error types
+
+Use dedicated error enums rather than generic `String` or `Box<dyn Error>`.
+
+```rust
+#[derive(Debug)]
+enum TranslateError {
+    InvalidOpcode(u32),
+    UnsupportedExtension(char),
+    BufferOverflow { requested: usize, available: usize },
+}
+```
+
+## Concurrency
+
+### Document lock ordering
+
+When multiple locks exist, document the acquisition order and follow it
+consistently to prevent deadlocks.
+
+### No I/O under spinlock
+
+Never perform I/O or blocking operations while holding a spinlock. This
+includes memory allocation and print statements.
+
+### Avoid casual atomics
+
+`Ordering` is subtle. Use `SeqCst` by default. Only relax to `Acquire`/
+`Release`/`Relaxed` when there is a documented performance reason and the
+correctness argument is written in a comment.
+
+## Performance
+
+### No O(n) on hot paths
+
+The translation fast path (TB lookup, code execution, TLB walk) must avoid
+O(n) operations. Use hash tables, direct-mapped caches, or indexed arrays.
+
+### Minimize unnecessary copies
+
+Pass large structures by reference. Use `&[u8]` instead of `Vec<u8>` when
+ownership is not needed. Avoid cloning `Arc` on every iteration.
+
+### No premature optimization
+
+Optimization commits must include a benchmark showing the improvement.
+
+## Macros and Attributes
+
+### Prefer functions over macros
+
+Use a macro only when a function cannot do the job (e.g., repeating
+declarations, generating match arms).
+
+### Suppress lints at narrowest scope
+
+Apply `#[allow(...)]` or `#[expect(...)]` to the specific item, not the entire
+module.
+
+### Sort derive traits alphabetically
+
+```rust
+#[derive(Clone, Copy, Debug, PartialEq, Eq)]
+```
+
+### Workspace lints
+
+Every workspace member must include:
+
+```toml
+[lints]
+workspace = true
+```

--- a/docs/zh/coding-guidelines.md
+++ b/docs/zh/coding-guidelines.md
@@ -1,0 +1,139 @@
+# Machina 编码指南
+
+Machina 项目的通用编码指南。Rust 特定规则见 [Rust 指南](rust-guidelines.md)，
+格式和命名约定见 [代码风格](coding-style.md)。
+
+## 命名
+
+### 描述性命名
+
+禁止单字母命名或含糊缩写。名称应揭示意图。
+
+```rust
+// Bad
+let v = t.read();
+let p = addr >> 12;
+
+// Good
+let value = temp.read();
+let page_number = addr >> PAGE_SHIFT;
+```
+
+### 准确命名
+
+名称必须与代码的实际行为一致。如果名称是"count"，值就应该是计数——
+而不是索引、偏移量或掩码。
+
+### 名称中编码单位
+
+当值携带物理单位或量级时，将其嵌入名称。
+
+```rust
+let timeout_ms = 5000;
+let frame_size_in_pages = 4;
+let clock_freq_hz = 12_000_000;
+```
+
+### 布尔值命名
+
+使用断言式命名：`is_*`、`has_*`、`can_*`、`should_*`。
+
+```rust
+let is_kernel_mode = mode == Prv::M;
+let has_side_effects = op.flags().contains(OpFlags::SIDE_EFFECT);
+```
+
+## 注释
+
+### 解释为什么，而不是什么
+
+重复代码的注释是噪音。解释非显而易见决策背后的原因。
+
+```rust
+// Bad: 重复代码
+// Check if page is present
+if pte.flags().contains(PteFlags::V) { ... }
+
+// Good: 解释约束
+// Sv39 spec: fetch falls through when V=0 in S-mode
+// only traps in M-mode (spec 4.3.1)
+if pte.flags().contains(PteFlags::V) { ... }
+```
+
+### 记录设计决策
+
+当存在多种方案时，记录选择当前方案的原因。未来的读者需要理解权衡，
+而不仅仅是结果。
+
+### 引用规范
+
+实现硬件行为时，引用规范章节。
+
+```rust
+// RISC-V Privileged Spec 4.3.1 -- PTE attribute for global mappings
+const PTE_G: u64 = 0x10;
+```
+
+## 文件组织
+
+### 每个文件一个概念
+
+当文件过长或混合了不相关的职责时，拆分文件。名为 `mmu.rs` 的文件
+不应包含中断处理逻辑。
+
+### 自上而下的阅读顺序
+
+高层入口点放在前面。辅助函数和内部细节放在后面。读者应能通过阅读
+第一个部分来理解公共 API。
+
+### 分组为逻辑段落
+
+在函数内部，将相关语句分组在一起。用空行分隔不同的组。每组应表达
+算法中的一个步骤。
+
+## API 设计
+
+### 隐藏实现细节
+
+默认使用最窄的可见性。只暴露调用者需要的内容。
+
+```rust
+// Prefer
+pub(crate) fn translate_one(ctx: &mut Context) { ... }
+
+// Avoid
+pub fn translate_one(ctx: &mut Context) { ... }
+```
+
+### 边界验证，内部信任
+
+在公共 API 边界（如 syscall 入口、设备 MMIO 写入）验证输入。
+在 crate 内部，信任已验证的值。
+
+### 用类型强制不变量
+
+如果值有约束，用类型系统编码，而不是在每个使用点检查。
+
+```rust
+// Prefer: 非法状态不可表示
+pub struct PhysicalPage(u64);
+
+impl PhysicalPage {
+    pub fn new(frame: u64) -> Option<Self> {
+        (frame < MAX_PHYS_PAGE).then_some(PhysicalPage(frame))
+    }
+}
+
+// Avoid: 原始 u64 可以是任何值
+fn map_page(frame: u64) { ... }
+```
+
+## 错误消息
+
+一致地格式化错误消息。包含失败的操作、涉及的值或标识符，以及
+（适用时）期望的范围。
+
+```
+"invalid PTE at {vpn}: reserved bits set"
+"out of TB cache: capacity {cap}, requested {size}"
+```

--- a/docs/zh/git-guidelines.md
+++ b/docs/zh/git-guidelines.md
@@ -1,0 +1,147 @@
+# Machina Git 指南
+
+Machina 项目的 Git 提交和 Pull Request 约定。
+
+## 提交消息
+
+### 格式
+
+```
+module: subject
+
+Body describing what changed and why.
+
+Signed-off-by: Name <email>
+```
+
+### Subject 行
+
+- 格式：`module: subject`
+- 祈使语气：`add`、`fix`、`remove`——而非 `added`、`fixed`、`removed`
+- 小写 subject，不加句号
+- 总长度不超过 72 字符
+
+### 常用 module 前缀
+
+| Module | 范围 |
+|--------|------|
+| `core` | IR 类型、操作码、CPU trait |
+| `accel` | IR 优化、寄存器分配、代码生成、执行引擎 |
+| `guest/riscv` | RISC-V 前端（解码、翻译） |
+| `decode` | .decode 解析器和代码生成 |
+| `system` | CPU 管理器、GDB 桥接、WFI |
+| `memory` | AddressSpace、MMIO、RAM 块 |
+| `hw/core` | 设备基础设施（qdev、IRQ、FDT） |
+| `hw/intc` | PLIC、ACLINT |
+| `hw/char` | UART |
+| `hw/riscv` | 参考机器、启动、SBI |
+| `hw/virtio` | VirtIO MMIO 传输和设备 |
+| `monitor` | QMP/HMP 控制台 |
+| `gdbstub` | GDB 远程协议 |
+| `difftest` | 差分测试客户端 |
+| `tests` | 测试套件 |
+| `docs` | 文档 |
+| `project` | 跨模块变更（CI、Makefile、配置） |
+
+### 常用动词前缀
+
+| 动词 | 用途 |
+|------|------|
+| `Fix` | 修复缺陷 |
+| `Add` | 引入新功能 |
+| `Remove` | 删除代码或功能 |
+| `Refactor` | 不改变行为的重构 |
+| `Rename` | 更改文件、模块或符号名称 |
+| `Implement` | 添加新的子系统或功能 |
+| `Enable` | 启用之前禁用的功能 |
+| `Clean up` | 无功能变更的小清理 |
+| `Bump` | 更新依赖版本 |
+
+### Body
+
+- 与 subject 之间空一行
+- 描述修改了什么以及为什么——而非如何实现
+- 每行不超过 80 字符
+
+### 示例
+
+```
+accel: fix register clobber in div/rem helpers
+
+The x86-64 backend used RDX as a scratch register for division
+without saving the guest's original value. Add save/restore around
+the DIV instruction.
+
+Signed-off-by: Chao Liu <chao.liu.zevorn@gmail.com>
+```
+
+```
+guest/riscv: implement Zbs (single-bit operations)
+
+Add bclr, bset, binv, bext for both register and immediate forms.
+The decoder now recognizes the Zbs extension when enabled in
+misa.
+
+Signed-off-by: Chao Liu <chao.liu.zevorn@gmail.com>
+```
+
+## 原子提交
+
+### 一个提交只做一件事
+
+每个提交必须只做一个逻辑变更。不要在单个提交中混合不相关的变更。
+如果你在提交消息中写了"以及"，就应该拆分。
+
+### 每个提交必须编译通过且测试通过
+
+每个提交之后，代码树必须处于可工作状态。禁止有破坏性的中间状态。
+这确保 `git bisect` 始终有效。
+
+### 提交 PR 前合并临时补丁
+
+在提交 PR 之前审查自己的分支时，将所有临时提交合并到它们所属的
+提交中。临时提交包括：
+
+- 修正早期提交中引入的拼写错误或缺陷的修复补丁
+- 调整先前变更的补丁（如重命名、重新排序）
+- 任何消息以 `fixup!` 或 `squash!` 开头的提交
+
+使用 `git rebase -i` 将这些临时提交折叠到原始提交中。最终 PR 的
+历史应该是一组干净的逻辑变更序列，而不是开发日记。
+
+### 重构与功能分离
+
+如果功能需要预备性的重构，将重构放在独立的提交中，在功能提交之前。
+这使得每个提交更容易审查和二分定位。
+
+## Signed-off-by
+
+本仓库的所有提交必须包含 `Signed-off-by` 行：
+
+```
+Signed-off-by: Chao Liu <chao.liu.zevorn@gmail.com>
+```
+
+禁止添加 AI 相关的签名行（如 `Co-Authored-By: Claude`）。
+
+## Pull Request
+
+### 保持 PR 专注
+
+一个 PR 一个主题。混合了缺陷修复、重构和新功能的 PR 难以审查。
+
+### CI 必须通过
+
+请求 review 前确保所有 CI 检查通过：
+
+- `make test`——所有测试通过
+- `make clippy`——零警告
+- `make fmt-check`——格式正确
+
+### 引用 issue
+
+当 PR 解决某个 issue 时，在描述中引用：
+
+```
+Closes #42
+```

--- a/docs/zh/rust-guidelines.md
+++ b/docs/zh/rust-guidelines.md
@@ -1,0 +1,186 @@
+# Machina Rust 指南
+
+Machina 项目的 Rust 特定指南。通用编码规则见 [编码指南](coding-guidelines.md)，
+格式约定见 [代码风格](coding-style.md)。
+
+## Unsafe Rust
+
+### 每次使用 unsafe 都需要理由
+
+每个 `unsafe` 块都需要 `// SAFETY:` 注释解释操作为何安全。
+每个 `unsafe fn` 或 `unsafe trait` 都需要 `# Safety` 文档段落，
+描述调用者必须满足的条件。
+
+```rust
+// SAFETY: buf points to a valid, RWX-mapped region of `len` bytes.
+// The mmap call above guaranteed alignment and permissions.
+unsafe { core::ptr::copy_nonoverlapping(src.as_ptr(), buf, len) }
+```
+
+### unsafe 仅限于特定模块
+
+`unsafe` 仅允许用于 JIT 代码缓冲区管理、生成代码的函数指针转换、
+TLB 快速路径中的原始指针访问、后端发射器中的内联汇编和 FFI。
+所有其他代码必须是安全 Rust。
+
+## 函数
+
+### 保持函数小而专注
+
+一个函数做一件事。如果需要注释来分隔段落，考虑拆分。
+
+### 最小化嵌套
+
+目标最多 3 层嵌套。使用提前返回、`let...else` 和 `?` 来展平控制流。
+
+```rust
+// Prefer
+let Some(pte) = page_table.walk(vpn) else {
+    return Err(MmuFault::InvalidPte);
+};
+
+// Avoid
+if let Some(pte) = page_table.walk(vpn) {
+    // ... deeply nested logic ...
+}
+```
+
+### 避免布尔参数
+
+使用枚举或拆分为两个函数。
+
+```rust
+// Prefer
+pub fn emit_load_signed(buf: &mut CodeBuffer, ...) { ... }
+pub fn emit_load_unsigned(buf: &mut CodeBuffer, ...) { ... }
+
+// Avoid
+pub fn emit_load(buf: &mut CodeBuffer, signed: bool, ...) { ... }
+```
+
+## 类型与 Trait
+
+### 封闭集合优先用枚举
+
+当变体集合在编译期已知时，使用枚举。trait 对象（`dyn Trait`）仅适用于
+开放式扩展。
+
+```rust
+// Prefer
+enum Exception {
+    InstructionAccessFault,
+    LoadAccessFault,
+    StoreAccessFault,
+    // ...
+}
+
+// Avoid
+trait Exception { fn handle(&self); }
+```
+
+### 通过 getter 封装字段
+
+通过方法暴露字段而非直接 `pub`。这保留了后续添加验证或日志的能力。
+
+## 模块与 Crate
+
+### 默认使用最窄可见性
+
+默认使用 `pub(super)` 或 `pub(crate)`。仅在外部 crate 确实需要访问时
+才使用 `pub`。
+
+### 通过父模块限定函数导入
+
+导入父模块，然后通过它调用函数。这使来源更明确。
+
+```rust
+// Prefer
+use core::mem;
+mem::replace(&mut slot, new_value)
+
+// Avoid
+use core::mem::replace;
+replace(&mut slot, new_value)
+```
+
+### 使用 workspace 依赖
+
+所有共享依赖版本必须在 workspace 根 `Cargo.toml` 的
+`[workspace.dependencies]` 中声明。各 crate 使用 `{ workspace = true }`
+引用。
+
+## 错误处理
+
+### 用 `?` 传播错误
+
+在可能失败的地方不要 `.unwrap()` 或 `.expect()`。使用 `?` 将错误
+传播给调用者。
+
+### 定义领域错误类型
+
+使用专用的错误枚举而非泛型 `String` 或 `Box<dyn Error>`。
+
+```rust
+#[derive(Debug)]
+enum TranslateError {
+    InvalidOpcode(u32),
+    UnsupportedExtension(char),
+    BufferOverflow { requested: usize, available: usize },
+}
+```
+
+## 并发
+
+### 记录锁顺序
+
+当存在多个锁时，文档化获取顺序并始终一致地遵守，以防止死锁。
+
+### 自旋锁下不做 I/O
+
+持有自旋锁时绝不执行 I/O 或阻塞操作。这包括内存分配和打印语句。
+
+### 避免随意使用原子操作
+
+`Ordering` 非常微妙。默认使用 `SeqCst`。仅在具有文档化的性能原因
+且正确性论证已写入注释时，才放宽为 `Acquire`/`Release`/`Relaxed`。
+
+## 性能
+
+### 热路径禁止 O(n)
+
+翻译快速路径（TB 查找、代码执行、TLB 遍历）必须避免 O(n) 操作。
+使用哈希表、直接映射缓存或索引数组。
+
+### 最小化不必要的拷贝
+
+通过引用传递大型结构体。当不需要所有权时使用 `&[u8]` 而非 `Vec<u8>`。
+避免在每次迭代中克隆 `Arc`。
+
+### 不要过早优化
+
+优化提交必须包含显示改进的基准测试。
+
+## 宏与属性
+
+### 函数优先于宏
+
+仅在函数无法完成工作时使用宏（例如重复声明、生成 match 分支）。
+
+### 在最窄范围抑制 lint
+
+将 `#[allow(...)]` 或 `#[expect(...)]` 应用于特定项，而非整个模块。
+
+### derive trait 按字母排序
+
+```rust
+#[derive(Clone, Copy, Debug, PartialEq, Eq)]
+```
+
+### Workspace lints
+
+每个 workspace 成员必须包含：
+
+```toml
+[lints]
+workspace = true
+```

--- a/gdbstub/Cargo.toml
+++ b/gdbstub/Cargo.toml
@@ -6,3 +6,6 @@ license.workspace = true
 repository.workspace = true
 authors.workspace = true
 description = "GDB Remote Serial Protocol server"
+
+[lints]
+workspace = true

--- a/guest/riscv/Cargo.toml
+++ b/guest/riscv/Cargo.toml
@@ -16,3 +16,6 @@ libc = { workspace = true }
 
 [build-dependencies]
 machina-decode = { workspace = true }
+
+[lints]
+workspace = true

--- a/hw/char/Cargo.toml
+++ b/hw/char/Cargo.toml
@@ -14,3 +14,6 @@ machina-core = { workspace = true }
 machina-hw-core = { workspace = true }
 machina-memory = { workspace = true }
 parking_lot = { workspace = true }
+
+[lints]
+workspace = true

--- a/hw/core/Cargo.toml
+++ b/hw/core/Cargo.toml
@@ -13,3 +13,6 @@ categories = ["emulators", "hardware-support"]
 machina-core = { workspace = true }
 machina-memory = { workspace = true }
 libc = { workspace = true }
+
+[lints]
+workspace = true

--- a/hw/intc/Cargo.toml
+++ b/hw/intc/Cargo.toml
@@ -14,3 +14,6 @@ machina-core = { workspace = true }
 machina-hw-core = { workspace = true }
 machina-memory = { workspace = true }
 parking_lot = { workspace = true }
+
+[lints]
+workspace = true

--- a/hw/intc/src/aclint.rs
+++ b/hw/intc/src/aclint.rs
@@ -201,9 +201,9 @@ impl Aclint {
 
     /// Set mtimecmp[hart] directly (for SBI SET_TIMER).
     ///
-    /// Equivalent to a guest write at ACLINT_BASE + 0x4000
-    /// + hart * 8; used by the host SBI backend in builtin
-    /// mode so it does not need to go through MMIO decode.
+    /// Equivalent to a guest write at ACLINT_BASE + 0x4000 +
+    /// hart * 8; used by the host SBI backend in builtin mode
+    /// so it does not need to go through MMIO decode.
     pub fn set_mtimecmp(&self, hart: usize, val: u64) {
         const MTIMECMP_OFF: u64 = 0x4000;
         self.write(MTIMECMP_OFF + hart as u64 * 8, 8, val);

--- a/hw/riscv/Cargo.toml
+++ b/hw/riscv/Cargo.toml
@@ -21,3 +21,6 @@ machina-memory = { workspace = true }
 machina-guest-riscv = { workspace = true }
 machina-hw-virtio = { workspace = true }
 sbi-spec = { workspace = true }
+
+[lints]
+workspace = true

--- a/hw/virtio/Cargo.toml
+++ b/hw/virtio/Cargo.toml
@@ -14,3 +14,6 @@ machina-core = { workspace = true }
 machina-hw-core = { workspace = true }
 machina-memory = { workspace = true }
 libc = { workspace = true }
+
+[lints]
+workspace = true

--- a/memory/Cargo.toml
+++ b/memory/Cargo.toml
@@ -12,3 +12,6 @@ categories = ["emulators"]
 [dependencies]
 machina-core = { workspace = true }
 libc = { workspace = true }
+
+[lints]
+workspace = true

--- a/monitor/Cargo.toml
+++ b/monitor/Cargo.toml
@@ -12,3 +12,6 @@ categories = ["emulators", "development-tools::debugging"]
 [dependencies]
 machina-core = { workspace = true }
 serde_json = { workspace = true }
+
+[lints]
+workspace = true

--- a/rust-toolchain.toml
+++ b/rust-toolchain.toml
@@ -1,0 +1,3 @@
+[toolchain]
+channel = "stable"
+components = ["rust-src"]

--- a/softfloat/Cargo.toml
+++ b/softfloat/Cargo.toml
@@ -6,3 +6,6 @@ description = "Pure software IEEE 754 floating-point library"
 license.workspace = true
 
 [dependencies]
+
+[lints]
+workspace = true

--- a/system/Cargo.toml
+++ b/system/Cargo.toml
@@ -15,3 +15,6 @@ machina-accel = { workspace = true }
 machina-guest-riscv = { workspace = true }
 machina-memory = { workspace = true }
 machina-gdbstub = { workspace = true }
+
+[lints]
+workspace = true

--- a/tests/Cargo.toml
+++ b/tests/Cargo.toml
@@ -23,3 +23,6 @@ machina-softfloat = { workspace = true }
 libc = { workspace = true }
 serde_json = { workspace = true }
 tempfile = { workspace = true }
+
+[lints]
+workspace = true

--- a/tests/mtest/Cargo.toml
+++ b/tests/mtest/Cargo.toml
@@ -6,3 +6,6 @@ publish = false
 
 [dependencies]
 machina-core = { workspace = true }
+
+[lints]
+workspace = true

--- a/tools/difftest/Cargo.toml
+++ b/tools/difftest/Cargo.toml
@@ -8,3 +8,6 @@ repository.workspace = true
 authors.workspace = true
 keywords = ["riscv", "testing", "emulator"]
 categories = ["emulators", "development-tools::testing"]
+
+[lints]
+workspace = true

--- a/tools/irbackend/Cargo.toml
+++ b/tools/irbackend/Cargo.toml
@@ -10,3 +10,6 @@ path = "src/main.rs"
 
 [dependencies]
 machina-accel = { workspace = true }
+
+[lints]
+workspace = true

--- a/tools/irdump/Cargo.toml
+++ b/tools/irdump/Cargo.toml
@@ -12,3 +12,6 @@ path = "src/main.rs"
 machina-accel = { workspace = true }
 machina-disas = { workspace = true }
 machina-guest-riscv = { workspace = true }
+
+[lints]
+workspace = true

--- a/util/Cargo.toml
+++ b/util/Cargo.toml
@@ -8,3 +8,6 @@ repository.workspace = true
 authors.workspace = true
 keywords = ["riscv", "emulator"]
 categories = ["emulators"]
+
+[lints]
+workspace = true


### PR DESCRIPTION
## Summary

- Add `Makefile` with build, test, and lint targets for streamlined development
- Add `rust-toolchain.toml` pinning stable channel, extend `.rustfmt.toml`, and configure strict workspace-level Clippy lints (all/pedantic/nursery)
- Integrate CI: update `check.yml` with clippy step, simplify `machina-tests.yml` to use `make test`, add new `docs.yml` for rustdoc generation
- Rewrite `CLAUDE.md` as the authoritative rules source; simplify `AGENTS.md` to a one-line pointer
- Add coding, Rust, and Git guidelines in both English and Chinese under `docs/en/` and `docs/zh/`

## Changes

| Commit | Scope |
|--------|-------|
| `dd16bdc` | Toolchain config + workspace lints for all 21 crates |
| `4a92672` | `Makefile` (build/release/test/clippy/fmt/docs/clean) |
| `620bdf9` | CI: clippy in `check.yml`, `make test` in tests, new `docs.yml` |
| `e78db0d` | CLAUDE.md as rules source, AGENTS.md points to it |
| `f67ca2c` | 6 guideline docs (coding, Rust, Git -- en + zh) |

## Test plan

- [x] `make build` passes
- [x] `make test` passes (1370 tests)
- [x] `make clippy` passes
- [x] `make fmt-check` passes
- [x] `make docs` passes
- [x] Each commit compiles independently (bisectable)