### PR TITLE
hw: simplify uart register dispatch and remove dead code

### DIFF
--- a/hw/char/src/uart.rs
+++ b/hw/char/src/uart.rs
@@ -414,74 +414,55 @@ impl Uart16550 {
 
     pub fn read(&self, offset: u64) -> u8 {
         let mut regs = self.regs.borrow();
-        match offset & 0x7 {
-            0 => {
-                if regs.lcr & LCR_DLAB != 0 {
-                    regs.dll
-                } else {
-                    let ch = Self::read_rbr(&mut regs);
-                    drop(regs);
-                    self.update_irq();
-                    ch
-                }
+        let dlab = regs.lcr & LCR_DLAB != 0;
+        match (offset & 0x7, dlab) {
+            (0, true) => regs.dll,
+            (0, false) => {
+                let ch = Self::read_rbr(&mut regs);
+                drop(regs);
+                self.update_irq();
+                ch
             }
-            1 => {
-                if regs.lcr & LCR_DLAB != 0 {
-                    regs.dlm
-                } else {
-                    regs.ier
-                }
-            }
-            2 => regs.iir,
-            3 => regs.lcr,
-            4 => regs.mcr,
-            5 => regs.lsr,
-            6 => regs.msr,
-            7 => regs.scr,
+            (1, true) => regs.dlm,
+            (1, false) => regs.ier,
+            (2, _) => regs.iir,
+            (3, _) => regs.lcr,
+            (4, _) => regs.mcr,
+            (5, _) => regs.lsr,
+            (6, _) => regs.msr,
+            (7, _) => regs.scr,
             _ => 0,
         }
     }
 
     pub fn write(&self, offset: u64, val: u8) {
-        match offset & 0x7 {
-            0 => {
-                let dlab = self.regs.borrow().lcr & LCR_DLAB != 0;
-                if dlab {
-                    self.regs.borrow().dll = val;
-                } else {
-                    self.write_thr(val);
-                }
+        let dlab = self.regs.borrow().lcr & LCR_DLAB != 0;
+        match (offset & 0x7, dlab) {
+            (0, true) => self.regs.borrow().dll = val,
+            (0, false) => self.write_thr(val),
+            (1, true) => self.regs.borrow().dlm = val,
+            (1, false) => {
+                self.regs.borrow().ier = val & 0x0F;
+                self.update_irq();
             }
-            1 => {
-                let dlab = self.regs.borrow().lcr & LCR_DLAB != 0;
-                if dlab {
-                    self.regs.borrow().dlm = val;
-                } else {
-                    self.regs.borrow().ier = val & 0x0F;
-                    self.update_irq();
-                }
-            }
-            2 => {
+            (2, _) => {
                 let mut regs = self.regs.borrow();
                 regs.fcr = val;
                 if val & 0x02 != 0 {
-                    // Clear RX FIFO.
                     regs.rx_fifo.clear();
                     regs.lsr &= !LSR_DR;
                     drop(regs);
                     self.update_irq();
                 }
             }
-            3 => self.regs.borrow().lcr = val,
-            4 => {
+            (3, _) => self.regs.borrow().lcr = val,
+            (4, _) => {
                 let has_cd = self.chardev.borrow().is_some();
                 let mut regs = self.regs.borrow();
                 regs.mcr = val;
                 regs.update_msr(has_cd);
             }
-            5 => {} // LSR is read-only
-            6 => {} // MSR is read-only
-            7 => self.regs.borrow().scr = val,
+            (7, _) => self.regs.borrow().scr = val,
             _ => {}
         }
     }

--- a/hw/core/src/chardev.rs
+++ b/hw/core/src/chardev.rs
@@ -29,8 +29,6 @@ pub trait Chardev: Send + Sync {
     fn start_input(&mut self, _cb: ByteCb) {}
 }
 
-// -- CharFrontend ------------------------------------------------
-
 /// Bridges a device (frontend) to a chardev backend.
 pub struct CharFrontend {
     backend: Box<dyn Chardev>,
@@ -155,8 +153,6 @@ impl MObject for ChardevObject {
     }
 }
 
-// -- NullChardev -------------------------------------------------
-
 /// Discards all output and never produces input.
 pub struct NullChardev;
 
@@ -171,8 +167,6 @@ impl Chardev for NullChardev {
         false
     }
 }
-
-// -- StdioChardev ------------------------------------------------
 
 /// Wraps host stdin/stdout with QEMU-compatible escape
 /// sequences (Ctrl+A prefix):
@@ -383,8 +377,6 @@ fn restore_termios(orig: &libc::termios) {
         libc::tcsetattr(0, libc::TCSANOW, orig);
     }
 }
-
-// -- SocketChardev -----------------------------------------------
 
 /// Unix-socket backed chardev (for integration testing).
 pub struct SocketChardev {

--- a/hw/core/src/fdt.rs
+++ b/hw/core/src/fdt.rs
@@ -127,8 +127,6 @@ impl FdtBuilder {
         blob
     }
 
-    // ---- internal helpers ----
-
     fn push_u32(&mut self, val: u32) {
         self.struct_buf.extend_from_slice(&val.to_be_bytes());
     }

--- a/hw/core/src/loader.rs
+++ b/hw/core/src/loader.rs
@@ -46,8 +46,6 @@ fn write_bytes(as_: &AddressSpace, base: GPA, data: &[u8]) {
     }
 }
 
-// ---- minimal ELF-64 constants ----
-
 const EI_MAG: [u8; 4] = [0x7f, b'E', b'L', b'F'];
 const ELFCLASS64: u8 = 2;
 const ET_EXEC: u16 = 2;

--- a/hw/intc/src/aclint.rs
+++ b/hw/intc/src/aclint.rs
@@ -101,8 +101,6 @@ impl Aclint {
         }
     }
 
-    // ---- Setup methods (delegate to locked state) ----
-
     pub fn attach_to_bus(&self, bus: &mut SysBus) -> Result<(), SysBusError> {
         self.state.lock().attach_to_bus(bus)
     }

--- a/hw/intc/src/plic.rs
+++ b/hw/intc/src/plic.rs
@@ -103,8 +103,6 @@ impl Plic {
         }
     }
 
-    // ---- Setup methods (delegate to locked state) ----
-
     pub fn attach_to_bus(&self, bus: &mut SysBus) -> Result<(), SysBusError> {
         self.state.lock().attach_to_bus(bus)
     }
@@ -304,8 +302,6 @@ impl Plic {
         }
         self.update_outputs();
     }
-
-    // ---- MMIO interface ----
 
     pub fn read(&self, offset: u64, size: u32) -> u64 {
         let _ = size;

--- a/hw/riscv/src/ref_machine.rs
+++ b/hw/riscv/src/ref_machine.rs
@@ -29,8 +29,6 @@ use crate::sifive_test::SifiveTest;
 
 type MonitorCallback = Arc<Mutex<dyn FnMut(u8) + Send>>;
 
-// ---- Centralized memory map (QEMU virt style) ----
-
 #[derive(Clone, Copy)]
 pub struct MemMapEntry {
     pub base: u64,
@@ -116,8 +114,6 @@ pub const VIRTIO_SLOT_COUNT: usize = 8;
 // PLIC context count is 2 * cpu_count (M-mode + S-mode per
 // hart), computed dynamically in init().
 
-// ---- CPU IRQ sink ----
-
 /// Per-hart IRQ sink that updates the real CPU mip bits.
 ///
 /// IRQ numbering (matches RISC-V privilege spec):
@@ -164,8 +160,6 @@ const IRQ_MTI: u32 = 7;
 const IRQ_MEI: u32 = 11;
 const IRQ_SEI: u32 = 9;
 
-// ---- MMIO adapter: SiFive Test ----
-
 struct SifiveTestMmio(Arc<SifiveTest>);
 
 impl MmioOps for SifiveTestMmio {
@@ -177,8 +171,6 @@ impl MmioOps for SifiveTestMmio {
         self.0.write(offset, size, val);
     }
 }
-
-// ---- RefMachine ----
 
 pub struct RefMachine {
     name: String,
@@ -421,16 +413,6 @@ impl RefMachine {
     pub fn take_cpu(&self, idx: usize) -> Option<RiscvCpu> {
         let mut lock = self.cpus.lock().unwrap();
         lock.get_mut(idx).and_then(|slot| slot.take())
-    }
-
-    /// Get a clone of the shared CPU vector Arc.
-    pub fn cpus_arc(&self) -> Arc<Mutex<Vec<Option<RiscvCpu>>>> {
-        Arc::clone(&self.cpus)
-    }
-
-    /// Expose the CPU vector for CpuManager integration.
-    pub fn cpus_shared(&self) -> Arc<Mutex<Vec<Option<RiscvCpu>>>> {
-        self.cpus.clone()
     }
 
     /// Shared mip for device IRQ delivery.
@@ -812,9 +794,6 @@ impl Machine for RefMachine {
             self.virtio_mmio = Some(virtio_mmio);
         }
 
-        // ---- IRQ wiring ----
-        // Per-hart CPU IRQ sinks update real csr.mip bits.
-
         // UART IRQ source -> PLIC.
         let plic_as_sink =
             Arc::new(PlicIrqSink(Arc::clone(self.plic.as_ref().unwrap())));
@@ -827,7 +806,6 @@ impl Machine for RefMachine {
             REF_IRQMAP.uart0,
         ));
 
-        // ---- Connect PLIC context outputs ----
         // All IRQ sinks write to shared_mip which is
         // read by FullSystemCpu::pending_interrupt().
         {
@@ -852,7 +830,6 @@ impl Machine for RefMachine {
             }
         }
 
-        // ---- Connect ACLINT MTI/MSI outputs ----
         {
             let mip = &self.shared_mip;
             let wk = &self.wfi_waker;
@@ -893,7 +870,6 @@ impl Machine for RefMachine {
             }
         }
 
-        // ---- Attach IRQ + chardev to UART ----
         {
             let backend: Box<dyn Chardev + Send> = if opts.nographic {
                 let mut sc = StdioChardev::new();


### PR DESCRIPTION
## Summary

- Flatten uart `read()`/`write()` with `(offset, dlab)` tuple matching instead of nested if-else per register — caches DLAB flag once per call, eliminates repeated borrows in `write()`
- Remove dead `cpus_arc()`/`cpus_shared()` methods from `RefMachine` (zero callers)
- Strip section-separator comments (`// ----`) from chardev, fdt, loader, plic, aclint, and ref_machine

Net result: **−61 lines** across 7 `hw/` files, zero behavior change.

## Test plan

- [x] `make fmt-check` passes
- [x] `make clippy` passes (zero warnings)
- [x] `cargo test -p machina-tests` — 1370 passed, 0 failed, 2 ignored