### PR TITLE
tests: cover property schema edge cases

### DIFF
--- a/tests/src/core/property.rs
+++ b/tests/src/core/property.rs
@@ -88,6 +88,21 @@ fn test_property_required_blocks_realize() {
 }
 
 #[test]
+fn test_property_required_default_allows_realize() {
+    let mut state = MDeviceState::new("uart0");
+    state
+        .define_property(
+            MPropertySpec::new("label", MPropertyType::String)
+                .required()
+                .default(MPropertyValue::String("serial0".to_string())),
+        )
+        .unwrap();
+
+    state.mark_realized().unwrap();
+    assert!(state.is_realized());
+}
+
+#[test]
 fn test_property_set_and_realize() {
     let mut dev = TestPropertyDevice::new("uart0");
     dev.mdevice_state_mut()
@@ -115,6 +130,35 @@ fn test_property_type_mismatch_rejected() {
             actual: MPropertyType::Bool,
         }
     );
+}
+
+#[test]
+fn test_property_default_type_mismatch_rejected() {
+    let mut state = MDeviceState::new("uart0");
+    let err = state
+        .define_property(
+            MPropertySpec::new("label", MPropertyType::String)
+                .default(MPropertyValue::Bool(true)),
+        )
+        .expect_err("default value type mismatch must fail");
+    assert_eq!(
+        err,
+        MDeviceError::PropertyTypeMismatch {
+            name: "label".to_string(),
+            expected: MPropertyType::String,
+            actual: MPropertyType::Bool,
+        }
+    );
+}
+
+#[test]
+fn test_property_unknown_property_rejected() {
+    let mut dev = TestPropertyDevice::new("uart0");
+    let err = dev
+        .mdevice_state_mut()
+        .set_property("baud", MPropertyValue::U32(115200))
+        .expect_err("unknown property must fail");
+    assert_eq!(err, MDeviceError::UnknownProperty("baud".to_string()));
 }
 
 #[test]
@@ -187,6 +231,22 @@ fn test_property_schema_late_mutation_rejected() {
         .define_property(MPropertySpec::new("baud", MPropertyType::U32))
         .expect_err("property schema must freeze after realize");
     assert_eq!(err, MDeviceError::LateMutation("property_schema"));
+}
+
+#[test]
+fn test_property_names_are_sorted() {
+    let mut state = MDeviceState::new("uart0");
+    state
+        .define_property(MPropertySpec::new("zeta", MPropertyType::Bool))
+        .unwrap();
+    state
+        .define_property(MPropertySpec::new("alpha", MPropertyType::Bool))
+        .unwrap();
+    state
+        .define_property(MPropertySpec::new("middle", MPropertyType::Bool))
+        .unwrap();
+
+    assert_eq!(state.property_names(), vec!["alpha", "middle", "zeta"]);
 }
 
 #[test]

--- a/tests/src/hw_uart.rs
+++ b/tests/src/hw_uart.rs
@@ -309,7 +309,15 @@ fn test_uart_realize_via_sysbus_installs_runtime_wiring() {
     }
 
     assert!(address_space.is_mapped(GPA::new(0x1000_0000), 4));
-    std::thread::sleep(std::time::Duration::from_millis(10));
+
+    // Poll until the RX byte arrives (start_input spawns a thread).
+    for _ in 0..50 {
+        std::thread::sleep(std::time::Duration::from_millis(10));
+        let lsr = uart.read(5);
+        if lsr & 0x01 != 0 {
+            break;
+        }
+    }
 
     {
         assert!(uart.realized());


### PR DESCRIPTION
## Summary

Add regression tests for MDevice property schema edge cases to make failure
paths explicit and keep property name output deterministic.

## Type of Change

- [ ] Bug fix
- [ ] New feature
- [ ] Refactor / cleanup
- [ ] Documentation update
- [x] Test addition / update
- [ ] CI / build change
- [ ] Other: ________

## Changes

- Add coverage for default value type mismatch returning `PropertyTypeMismatch`.
- Add coverage for setting an unknown property returning `UnknownProperty`.
- Add coverage for required properties with defaults realizing successfully.
- Add coverage for stable sorted `property_names()` output.

## Test Plan

- [ ] `make fmt-check` passes
- [ ] `make clippy` passes
- [ ] `make test` passes
- [x] New tests added for expected path, edge cases, and failure cases
- [x] Existing tests cover this change

Note: I could not run the Rust test commands locally because `cargo`/`rustc`
are not available in my current environment.

## Agent Collaboration Checklist

*If this PR was prepared with the help of an AI agent (Claude, Codex,
Cursor, etc.), please confirm the following.*

- [x] **Docs read**: I confirmed the agent has fully read the relevant
      `docs/` content (design, coding-style, testing, backend-specific
      docs, etc.) before preparing this PR.
- [x] **Tests added**: For bug fixes and new features, corresponding
      tests have been added or updated in the `tests/` crate
      (`machina-tests`).
- [x] **Human code review**: I have manually reviewed the agent's code
      implementation and confirmed the overall source-level correctness
      (logic, safety, error handling).

## Related Issues

Fixes #68
