### PR TITLE
docs(monitor): replace duplicate messages with meaningful information

### DIFF
--- a/monitor/src/hmp.rs
+++ b/monitor/src/hmp.rs
@@ -27,15 +27,15 @@ pub fn handle_line(
     match cmd {
         "info" => handle_info(arg, svc),
         "stop" => {
-            svc.lock().unwrap().stop();
+            svc.lock().expect("monitor mutex poisoned").stop();
             Some(String::new())
         }
         "cont" | "c" => {
-            svc.lock().unwrap().cont();
+            svc.lock().expect("monitor mutex poisoned").cont();
             Some(String::new())
         }
         "quit" | "q" => {
-            svc.lock().unwrap().quit();
+            svc.lock().expect("monitor mutex poisoned").quit();
             None // signals exit
         }
         "help" | "?" => Some(help_text()),
@@ -44,7 +44,7 @@ pub fn handle_line(
 }
 
 fn handle_info(arg: &str, svc: &Arc<Mutex<MonitorService>>) -> Option<String> {
-    let s = svc.lock().unwrap();
+    let s = svc.lock().expect("monitor mutex poisoned");
     match arg.trim() {
         "status" => {
             let running = s.query_status();

--- a/monitor/src/mmp.rs
+++ b/monitor/src/mmp.rs
@@ -27,7 +27,7 @@ pub fn run_tcp(listener: TcpListener, svc: Arc<Mutex<MonitorService>>) {
                 }
             }
             Err(_) => {
-                if svc.lock().unwrap().state.is_quit_requested() {
+                if svc.lock().expect("monitor mutex poisoned").state.is_quit_requested() {
                     break;
                 }
             }
@@ -43,7 +43,7 @@ fn handle_connection(
     let _ = writeln!(stream, "{}", GREETING);
     let _ = stream.flush();
 
-    let reader = BufReader::new(stream.try_clone().unwrap());
+    let reader = BufReader::new(stream.try_clone().expect("failed to clone monitor stream"));
     let mut caps_done = false;
 
     for line in reader.lines() {
@@ -104,7 +104,7 @@ fn handle_connection(
 
 /// Dispatch a command and return the JSON response.
 pub fn dispatch(cmd: &str, svc: &Arc<Mutex<MonitorService>>) -> Value {
-    let s = svc.lock().unwrap();
+    let s = svc.lock().expect("monitor mutex poisoned");
     match cmd {
         "qmp_capabilities" => json!({"return": {}}),
         "query-status" => {

--- a/monitor/src/mmp.rs
+++ b/monitor/src/mmp.rs
@@ -43,7 +43,7 @@ fn handle_connection(
     let _ = writeln!(stream, "{}", GREETING);
     let _ = stream.flush();
 
-    let reader = BufReader::new(stream.try_clone().expect("failed to clone monitor stream"));
+    let reader = BufReader::new(stream.try_clone().expect("monitor mutex poisoned"));
     let mut caps_done = false;
 
     for line in reader.lines() {


### PR DESCRIPTION
## Description
Replace repetitive placeholder messages in monitor modules with meaningful and descriptive information.

## Files Changed
- `monitor/src/hmp.rs`: Updated messages
- `monitor/src/mmp.rs`: Updated messages

## Type of Change
- [x] Documentation/Message improvement