### PR TITLE
ci: fix msys2 shell scope for cargo test step

### DIFF
--- a/.github/workflows/machina-tests.yml
+++ b/.github/workflows/machina-tests.yml
@@ -14,17 +14,12 @@ jobs:
         include:
           - os: ubuntu-latest
             name: linux
-            shell: bash
           - os: windows-latest
             name: msys2
-            shell: msys2 {0}
     runs-on: ${{ matrix.os }}
     timeout-minutes: 90
     env:
       CARGO_TERM_COLOR: always
-    defaults:
-      run:
-        shell: ${{ matrix.shell }}
 
     steps:
       - name: Checkout machina
@@ -69,5 +64,11 @@ jobs:
             gcc-riscv64-linux-gnu \
             qemu-user
 
-      - name: Run all tests
+      - name: Run all tests (Linux)
+        if: matrix.name == 'linux'
+        run: cargo test -p machina-tests
+
+      - name: Run all tests (Windows)
+        if: matrix.name == 'msys2'
+        shell: msys2 {0}
         run: cargo test -p machina-tests


### PR DESCRIPTION
## Summary

- Remove `defaults.run.shell` so `uses:` action steps
  (`dtolnay/rust-toolchain`, `Swatinem/rust-cache`) run
  in the runner's native shell instead of `msys2 {0}`
- Set `shell: msys2 {0}` only on the `cargo test` step
  that actually requires the MSYS2 environment
- Drop the now-redundant `shell` field from the matrix

## Root cause

`defaults.run.shell: msys2 {0}` applies to every `run:` step, including
those executed internally by composite actions. This causes the Rust
toolchain installer and cache action to run inside the MSYS2 shell
context, where path resolution and environment variables differ from
what those actions expect, leading to failures on the Windows runner.

## Test plan

- [ ] Windows (`msys2`) CI job passes: MSYS2 setup → Rust install → cache → `cargo test`
- [ ] Linux CI job is unaffected (no shell field change on that path)