### PR TITLE
main: fail fast when -kernel path does not exist (#82)

### DIFF
--- a/src/main.rs
+++ b/src/main.rs
@@ -151,11 +151,21 @@ fn parse_args() -> Result<CliArgs, String> {
                     .ok_or("-kernel requires argument")?
                     .clone()
                     .into();
-                if !path.exists() {
-                    return Err(format!(
-                        "-kernel: file not found: {}",
-                        path.display()
-                    ));
+                match path.try_exists() {
+                    Ok(true) => {}
+                    Ok(false) => {
+                        return Err(format!(
+                            "-kernel: file not found: {}",
+                            path.display()
+                        ));
+                    }
+                    Err(e) => {
+                        return Err(format!(
+                            "-kernel: cannot access {}: {}",
+                            path.display(),
+                            e
+                        ));
+                    }
                 }
                 cli.kernel = Some(path);
             }

--- a/src/main.rs
+++ b/src/main.rs
@@ -146,12 +146,18 @@ fn parse_args() -> Result<CliArgs, String> {
             }
             "-kernel" => {
                 i += 1;
-                cli.kernel = Some(
-                    args.get(i)
-                        .ok_or("-kernel requires argument")?
-                        .clone()
-                        .into(),
-                );
+                let path: PathBuf = args
+                    .get(i)
+                    .ok_or("-kernel requires argument")?
+                    .clone()
+                    .into();
+                if !path.exists() {
+                    return Err(format!(
+                        "-kernel: file not found: {}",
+                        path.display()
+                    ));
+                }
+                cli.kernel = Some(path);
             }
             "-nographic" => {
                 cli.nographic = true;

--- a/tests/src/cli_kernel.rs
+++ b/tests/src/cli_kernel.rs
@@ -1,0 +1,60 @@
+//! Regression tests for #82: `-kernel` should fail fast with a clear
+//! error when the file does not exist, instead of deferring the
+//! failure to ELF load inside `machina_system`.
+
+use std::path::PathBuf;
+use std::process::Command;
+use std::sync::{Mutex, OnceLock};
+
+fn project_root() -> PathBuf {
+    PathBuf::from(env!("CARGO_MANIFEST_DIR")).join("..")
+}
+
+fn machina_bin() -> PathBuf {
+    let base = project_root().join("target").join("debug").join("machina");
+    if cfg!(windows) {
+        base.with_extension("exe")
+    } else {
+        base
+    }
+}
+
+fn ensure_machina_built() {
+    // Serialise concurrent builds: on Windows multiple linkers cannot
+    // write the same .exe simultaneously.
+    static LOCK: OnceLock<Mutex<()>> = OnceLock::new();
+    let _guard = LOCK.get_or_init(Mutex::default).lock().unwrap();
+
+    let status = Command::new("cargo")
+        .args(["build", "-p", "machina-emu"])
+        .current_dir(project_root())
+        .status()
+        .expect("cargo build machina-emu failed");
+    assert!(status.success(), "cargo build machina-emu failed");
+}
+
+#[test]
+fn kernel_nonexistent_path_fails_fast() {
+    ensure_machina_built();
+
+    let bogus = "/this/path/does/not/exist/kernel.elf";
+    let output = Command::new(machina_bin())
+        .args(["-kernel", bogus])
+        .output()
+        .expect("failed to spawn machina");
+
+    assert!(
+        !output.status.success(),
+        "machina should reject a missing -kernel path; got success exit",
+    );
+
+    let stderr = String::from_utf8_lossy(&output.stderr);
+    assert!(
+        stderr.contains("-kernel: file not found"),
+        "expected 'file not found' message in stderr; got: {stderr}",
+    );
+    assert!(
+        stderr.contains(bogus),
+        "expected the offending path in stderr; got: {stderr}",
+    );
+}

--- a/tests/src/lib.rs
+++ b/tests/src/lib.rs
@@ -3,6 +3,8 @@ mod accel_timer;
 #[cfg(test)]
 mod backend;
 #[cfg(test)]
+mod cli_kernel;
+#[cfg(test)]
 mod cli_netdev;
 #[cfg(test)]
 mod core;


### PR DESCRIPTION
Closes #82.

The \`-kernel\` argument parser stored the path as-is and deferred the failure to ELF load inside \`machina_system\`, where the error was generic and didn't name the user-supplied path. Check existence with \`Path::exists()\` right after parsing and return a clear \`-kernel: file not found: <path>\` so the bad input is named at the layer that produced it.

Adds \`tests/src/cli_kernel.rs\` which builds \`machina-emu\` and invokes the binary against a non-existent kernel path, asserting both the non-zero exit and the \"file not found\" / path text in stderr. Mirrors the subprocess pattern in \`tests/src/tools/mod.rs\` (\`parse_args\` is not reachable from \`machina-tests\` directly because \`src/main.rs\` is a binary crate, not a library).

Note for reviewers: I am on aarch64-darwin, where \`machina-accel\` does not build (\`sysv64\` ABI is x86-64 only), so I could not run \`make test\` locally. The change itself passes \`cargo fmt --check\`. CI on x86-64 Linux will exercise the new test.