### PR TITLE
refactor(monitor): replace unwrap with expect on mutex/clone calls

### DIFF
--- a/monitor/src/hmp.rs
+++ b/monitor/src/hmp.rs
@@ -27,15 +27,15 @@ pub fn handle_line(
     match cmd {
         "info" => handle_info(arg, svc),
         "stop" => {
-            svc.lock().unwrap().stop();
+            svc.lock().expect("monitor mutex poisoned").stop();
             Some(String::new())
         }
         "cont" | "c" => {
-            svc.lock().unwrap().cont();
+            svc.lock().expect("monitor mutex poisoned").cont();
             Some(String::new())
         }
         "quit" | "q" => {
-            svc.lock().unwrap().quit();
+            svc.lock().expect("monitor mutex poisoned").quit();
             None // signals exit
         }
         "help" | "?" => Some(help_text()),
@@ -44,7 +44,7 @@ pub fn handle_line(
 }
 
 fn handle_info(arg: &str, svc: &Arc<Mutex<MonitorService>>) -> Option<String> {
-    let s = svc.lock().unwrap();
+    let s = svc.lock().expect("monitor mutex poisoned");
     match arg.trim() {
         "status" => {
             let running = s.query_status();

--- a/monitor/src/mmp.rs
+++ b/monitor/src/mmp.rs
@@ -27,7 +27,12 @@ pub fn run_tcp(listener: TcpListener, svc: Arc<Mutex<MonitorService>>) {
                 }
             }
             Err(_) => {
-                if svc.lock().unwrap().state.is_quit_requested() {
+                if svc
+                    .lock()
+                    .expect("monitor mutex poisoned")
+                    .state
+                    .is_quit_requested()
+                {
                     break;
                 }
             }
@@ -43,7 +48,8 @@ fn handle_connection(
     let _ = writeln!(stream, "{}", GREETING);
     let _ = stream.flush();
 
-    let reader = BufReader::new(stream.try_clone().unwrap());
+    let reader =
+        BufReader::new(stream.try_clone().expect("failed to clone TCP stream"));
     let mut caps_done = false;
 
     for line in reader.lines() {
@@ -104,7 +110,7 @@ fn handle_connection(
 
 /// Dispatch a command and return the JSON response.
 pub fn dispatch(cmd: &str, svc: &Arc<Mutex<MonitorService>>) -> Value {
-    let s = svc.lock().unwrap();
+    let s = svc.lock().expect("monitor mutex poisoned");
     match cmd {
         "qmp_capabilities" => json!({"return": {}}),
         "query-status" => {
@@ -113,7 +119,7 @@ pub fn dispatch(cmd: &str, svc: &Arc<Mutex<MonitorService>>) -> Value {
         }
         "stop" => {
             drop(s);
-            svc.lock().unwrap().stop();
+            svc.lock().expect("monitor mutex poisoned").stop();
             json!({"return": {}})
         }
         "cont" => {


### PR DESCRIPTION
## Summary

Resolves #90. The monitor module had `svc.lock().unwrap()` and `stream.try_clone().unwrap()` calls scattered across `monitor/src/hmp.rs` (lines 30/34/38/47) and `monitor/src/mmp.rs` (lines 30/46/107/116). When a poisoned mutex bubbles up, those unwraps panic with `"called \`Result::unwrap()\` on an \`Err\` value"` and no operator-facing context — useless for diagnosing which monitor surface failed.

## Why this matters

The issue calls this out in concrete terms: the operator gets a generic panic with no breadcrumb. Replacing each `unwrap()` with a contextual `expect(...)` keeps the same panic-on-poison semantics (no behaviour change) but the panic message now names the failing operation. The same idiom appears elsewhere in the workspace, so this is a focused mechanical change rather than introducing a new pattern.

I touched only the two files the issue listed and only the lines it listed (plus mmp.rs:116, which is a third `svc.lock().unwrap()` and matches the issue's "3 处 `svc.lock().unwrap()`" count even though only `30` and `107` were enumerated explicitly — keeping the file consistent rather than leaving one unfixed).

## Testing

- `cargo check -p machina-monitor` — clean.
- `cargo clippy -p machina-monitor` — no new warnings on this diff (the existing 31 are pre-existing and unrelated).
- `cargo test -p machina-monitor` — passes (the crate has no tests, so this is just a smoke build).
- `cargo fmt --manifest-path monitor/Cargo.toml --check` — clean.

`make clippy` itself still fails on the workspace because `machina-accel` has macOS-incompatible `extern "sysv64"` calling conventions (`E0570`) on `main`; that failure is unrelated to this PR.

Fixes #90
