### PR TITLE
monitor: implement system_powerdown MMP command (closes #88)

### DIFF
--- a/monitor/src/mmp.rs
+++ b/monitor/src/mmp.rs
@@ -101,7 +101,7 @@ fn handle_connection(
         if cmd == "qmp_capabilities" {
             caps_done = true;
         }
-        if cmd == "quit" {
+        if cmd == "quit" || cmd == "system_powerdown" {
             return true;
         }
     }
@@ -127,6 +127,13 @@ pub fn dispatch(cmd: &str, svc: &Arc<Mutex<MonitorService>>) -> Value {
             json!({"return": {}})
         }
         "quit" => {
+            s.quit();
+            json!({"return": {}})
+        }
+        "system_powerdown" => {
+            // QMP system_powerdown shuts down the VM. machina has no
+            // separate ACPI shutdown path, so reuse quit() which signals
+            // the run loop to stop -- semantically equivalent here.
             s.quit();
             json!({"return": {}})
         }

--- a/tests/src/monitor.rs
+++ b/tests/src/monitor.rs
@@ -137,6 +137,17 @@ fn test_mmp_quit() {
     assert!(svc.lock().unwrap().state.is_quit_requested());
 }
 
+#[test]
+fn test_mmp_system_powerdown() {
+    // QMP system_powerdown shuts down the VM. machina has no separate
+    // ACPI shutdown path, so dispatch must reuse quit() and return
+    // the empty success envelope.
+    let svc = make_svc();
+    let resp = mmp::dispatch("system_powerdown", &svc);
+    assert_eq!(resp["return"], serde_json::json!({}));
+    assert!(svc.lock().unwrap().state.is_quit_requested());
+}
+
 // ── HMP tests ───────────────────────────────────────
 
 #[test]


### PR DESCRIPTION
## Summary

Closes #88

The MMP dispatcher accepted `qmp_capabilities`, `query-status`, `stop`, `cont`, `quit`, `query-cpus-fast`, and `system_reset` (deferred). `system_powerdown` returned `CommandNotFound`, which prevented QMP clients from issuing the standard graceful-shutdown command against machina.

## Changes

- `monitor/src/mmp.rs`: add a `"system_powerdown"` arm to `dispatch()` that reuses the existing `MonitorService::quit()` path. machina has no separate ACPI shutdown path, so reusing the run-loop quit signal is the semantically equivalent behavior the issue called out.
- `monitor/src/mmp.rs`: extend `handle_connection()` to terminate the TCP session when it sees `system_powerdown` (previously only `quit` did this) so a client that issues `system_powerdown` over TCP no longer leaves the connection stuck and the server returning to `incoming()` despite quit being requested.
- `tests/src/monitor.rs`: add `test_mmp_system_powerdown`, mirroring the existing `test_mmp_quit`. Asserts the empty success envelope and `is_quit_requested()` flips after dispatch.

## Verification

Per the workshop description, this is a 4-line dispatch addition; the diff is 18 added lines including the regression test. `cargo build -p machina-monitor` is clean. `make clippy` and `make test` could not be run on this machine (the JIT crate `accel/` requires a host x86-64 target via `extern "sysv64"`); CI on the gevico/machina x86-64 runners will exercise the full quality gates.

Issue ref: gevico/machina#88
