### PR TITLE
cli: check -initrd file existence at parse time (#83)

### DIFF
--- a/src/main.rs
+++ b/src/main.rs
@@ -236,8 +236,28 @@ fn parse_args() -> Result<CliArgs, String> {
             }
             "-initrd" => {
                 i += 1;
-                let s = args.get(i).ok_or("-initrd requires argument")?;
-                cli.initrd = Some(PathBuf::from(s));
+                let path: PathBuf = args
+                    .get(i)
+                    .ok_or("-initrd requires argument")?
+                    .clone()
+                    .into();
+                match path.try_exists() {
+                    Ok(true) => {}
+                    Ok(false) => {
+                        return Err(format!(
+                            "-initrd: file not found: {}",
+                            path.display()
+                        ));
+                    }
+                    Err(e) => {
+                        return Err(format!(
+                            "-initrd: cannot access {}: {}",
+                            path.display(),
+                            e
+                        ));
+                    }
+                }
+                cli.initrd = Some(path);
             }
             "-monitor" => {
                 i += 1;

--- a/tests/src/cli_initrd.rs
+++ b/tests/src/cli_initrd.rs
@@ -1,0 +1,64 @@
+//! Regression tests for #83: `-initrd` should fail fast with a clear
+//! error when the file does not exist, instead of deferring the
+//! failure to a later boot stage with a confusing message.
+
+use std::path::PathBuf;
+use std::process::Command;
+use std::sync::{Mutex, OnceLock};
+
+fn project_root() -> PathBuf {
+    PathBuf::from(env!("CARGO_MANIFEST_DIR")).join("..")
+}
+
+fn machina_bin() -> PathBuf {
+    let base = project_root().join("target").join("debug").join("machina");
+    if cfg!(windows) {
+        base.with_extension("exe")
+    } else {
+        base
+    }
+}
+
+fn ensure_machina_built() {
+    // Serialise concurrent builds: on Windows multiple linkers cannot
+    // write the same .exe simultaneously.
+    static LOCK: OnceLock<Mutex<()>> = OnceLock::new();
+    let _guard = LOCK.get_or_init(Mutex::default).lock().unwrap();
+
+    let status = Command::new("cargo")
+        .args(["build", "-p", "machina-emu"])
+        .current_dir(project_root())
+        .status()
+        .expect("cargo build machina-emu failed");
+    assert!(status.success(), "cargo build machina-emu failed");
+}
+
+#[test]
+fn initrd_nonexistent_path_fails_fast() {
+    ensure_machina_built();
+
+    let bogus = "/this/path/does/not/exist/initrd.img";
+    let output = Command::new(machina_bin())
+        .args(["-initrd", bogus])
+        .output()
+        .expect("failed to spawn machina");
+
+    assert!(
+        !output.status.success(),
+        "machina should reject a missing -initrd path; got success exit",
+    );
+
+    let stderr = String::from_utf8_lossy(&output.stderr);
+    assert!(
+        stderr.contains("-initrd: file not found"),
+        "expected 'file not found' message in stderr; got: {stderr}",
+    );
+    assert!(
+        stderr.contains(bogus),
+        "expected the offending path in stderr; got: {stderr}",
+    );
+    assert!(
+        !stderr.contains("panicked at"),
+        "expected friendly error, not panic; got: {stderr}",
+    );
+}

--- a/tests/src/lib.rs
+++ b/tests/src/lib.rs
@@ -5,6 +5,8 @@ mod arch_exit;
 #[cfg(test)]
 mod backend;
 #[cfg(test)]
+mod cli_initrd;
+#[cfg(test)]
 mod cli_kernel;
 #[cfg(test)]
 mod cli_netdev;


### PR DESCRIPTION
## Summary

Closes #83. Mirror the `-kernel` validation pattern for `-initrd` so a
missing path is rejected at argument-parse time rather than at a later
boot stage where the failure mode is unclear.

- `src/main.rs`: in the `-initrd` arm of `parse_args()`, run `try_exists()`
  and return `-initrd: file not found: <path>` (or `-initrd: cannot
  access ...` on permission/IO errors) instead of blindly storing the
  path.
- `tests/src/cli_initrd.rs`: spawn `machina -initrd /bogus/path` and
  assert the stderr contains the friendly error plus the offending path,
  with no panic.

## Test plan

- [x] `cargo fmt --all --check`
- [x] `cargo clippy --workspace -- -D warnings -A clippy::pedantic -A clippy::nursery`
- [x] `cargo test -p machina-tests --lib cli_initrd`