### PR TITLE
cli: reject repeated -bios arguments (#84)

### DIFF
--- a/src/main.rs
+++ b/src/main.rs
@@ -179,6 +179,15 @@ fn parse_args() -> Result<CliArgs, String> {
             "-bios" => {
                 i += 1;
                 let arg = args.get(i).ok_or("-bios requires argument")?.clone();
+                if cli.bios_builtin || cli.bios.is_some() {
+                    // Repeated -bios silently dropped earlier values,
+                    // which let users believe both took effect. Reject
+                    // outright so the conflict surfaces immediately.
+                    return Err(
+                        "-bios: already specified; pass -bios at most once"
+                            .to_string(),
+                    );
+                }
                 if arg == "builtin" {
                     cli.bios_builtin = true;
                     cli.bios = None;

--- a/tests/src/cli_bios.rs
+++ b/tests/src/cli_bios.rs
@@ -1,0 +1,83 @@
+//! Regression tests for #84: repeated `-bios` arguments must be
+//! rejected with a clear error instead of silently letting the later
+//! value override the earlier one.
+
+use std::path::PathBuf;
+use std::process::Command;
+use std::sync::{Mutex, OnceLock};
+
+fn project_root() -> PathBuf {
+    PathBuf::from(env!("CARGO_MANIFEST_DIR")).join("..")
+}
+
+fn machina_bin() -> PathBuf {
+    let base = project_root().join("target").join("debug").join("machina");
+    if cfg!(windows) {
+        base.with_extension("exe")
+    } else {
+        base
+    }
+}
+
+fn ensure_machina_built() {
+    // Serialise concurrent builds: on Windows multiple linkers cannot
+    // write the same .exe simultaneously.
+    static LOCK: OnceLock<Mutex<()>> = OnceLock::new();
+    let _guard = LOCK.get_or_init(Mutex::default).lock().unwrap();
+
+    let status = Command::new("cargo")
+        .args(["build", "-p", "machina-emu"])
+        .current_dir(project_root())
+        .status()
+        .expect("cargo build machina-emu failed");
+    assert!(status.success(), "cargo build machina-emu failed");
+}
+
+fn assert_repeated_bios_rejected(args: &[&str]) {
+    ensure_machina_built();
+
+    let output = Command::new(machina_bin())
+        .args(args)
+        .output()
+        .expect("failed to spawn machina");
+
+    assert!(
+        !output.status.success(),
+        "machina should reject repeated -bios; got success exit for {args:?}",
+    );
+
+    let stderr = String::from_utf8_lossy(&output.stderr);
+    assert!(
+        stderr.contains("-bios: already specified"),
+        "expected repeated-bios rejection in stderr; got: {stderr}",
+    );
+    assert!(
+        !stderr.contains("panicked at"),
+        "expected friendly error, not panic; got: {stderr}",
+    );
+}
+
+#[test]
+fn repeated_bios_builtin_then_path_is_rejected() {
+    assert_repeated_bios_rejected(&[
+        "-bios",
+        "builtin",
+        "-bios",
+        "firmware.bin",
+    ]);
+}
+
+#[test]
+fn repeated_bios_path_then_builtin_is_rejected() {
+    assert_repeated_bios_rejected(&[
+        "-bios",
+        "firmware.bin",
+        "-bios",
+        "builtin",
+    ]);
+}
+
+#[test]
+fn repeated_bios_two_paths_is_rejected() {
+    assert_repeated_bios_rejected(&["-bios", "fw_a.bin", "-bios", "fw_b.bin"]);
+}

--- a/tests/src/lib.rs
+++ b/tests/src/lib.rs
@@ -5,6 +5,8 @@ mod arch_exit;
 #[cfg(test)]
 mod backend;
 #[cfg(test)]
+mod cli_bios;
+#[cfg(test)]
 mod cli_help;
 #[cfg(test)]
 mod cli_initrd;


### PR DESCRIPTION
## Summary

Closes #84. Reject any second `-bios` so the conflict surfaces at
parse time instead of silently overwriting the earlier value.

- `src/main.rs`: in the `-bios` arm of `parse_args()`, return
  `-bios: already specified; pass -bios at most once` whenever a value
  has already been recorded (covers builtin-then-path, path-then-builtin
  and two-paths cases).
- `tests/src/cli_bios.rs`: spawn `machina` with three repeated-`-bios`
  variants and assert a friendly error in stderr (no panic).

## Test plan

- [x] `cargo fmt --all --check`
- [x] `cargo clippy --workspace -- -D warnings -A clippy::pedantic -A clippy::nursery`
- [x] `cargo test -p machina-tests --lib cli_bios`