### PR TITLE
cli: reject -gdb stdio at parse time (#76)

### DIFF
--- a/src/main.rs
+++ b/src/main.rs
@@ -342,11 +342,19 @@ fn parse_args() -> Result<CliArgs, String> {
             "-gdb" => {
                 i += 1;
                 let s = args.get(i).ok_or("-gdb requires argument")?;
-                if s.starts_with("tcp:") || s == "stdio" {
-                    cli.gdb = Some(s.clone());
-                } else {
+                if s == "stdio" {
+                    // stdio mode was previously accepted at parse time
+                    // but the GDB server thread only handles tcp: and
+                    // silently dropped stdio, while still printing
+                    // "machina: gdb on stdio". Reject it explicitly.
+                    return Err("-gdb: stdio transport is not implemented; \
+                         use -gdb tcp:<host>:<port>"
+                        .to_string());
+                }
+                if !s.starts_with("tcp:") {
                     return Err(format!("-gdb: unsupported: {}", s));
                 }
+                cli.gdb = Some(s.clone());
             }
             "-h" | "--help" => {
                 usage();

--- a/tests/src/cli_gdb.rs
+++ b/tests/src/cli_gdb.rs
@@ -1,0 +1,85 @@
+//! Regression tests for #76: `-gdb stdio` was accepted at parse time
+//! but never wired up to a real RSP transport. Now reject it during
+//! argument parsing so users see the failure immediately instead of a
+//! misleading "machina: gdb on stdio" line followed by silent drop.
+
+use std::path::PathBuf;
+use std::process::Command;
+use std::sync::{Mutex, OnceLock};
+
+fn project_root() -> PathBuf {
+    PathBuf::from(env!("CARGO_MANIFEST_DIR")).join("..")
+}
+
+fn machina_bin() -> PathBuf {
+    let base = project_root().join("target").join("debug").join("machina");
+    if cfg!(windows) {
+        base.with_extension("exe")
+    } else {
+        base
+    }
+}
+
+fn ensure_machina_built() {
+    // Serialise concurrent builds: on Windows multiple linkers cannot
+    // write the same .exe simultaneously.
+    static LOCK: OnceLock<Mutex<()>> = OnceLock::new();
+    let _guard = LOCK.get_or_init(Mutex::default).lock().unwrap();
+
+    let status = Command::new("cargo")
+        .args(["build", "-p", "machina-emu"])
+        .current_dir(project_root())
+        .status()
+        .expect("cargo build machina-emu failed");
+    assert!(status.success(), "cargo build machina-emu failed");
+}
+
+#[test]
+fn gdb_stdio_is_rejected_at_parse_time() {
+    ensure_machina_built();
+
+    let output = Command::new(machina_bin())
+        .args(["-gdb", "stdio"])
+        .output()
+        .expect("failed to spawn machina");
+
+    assert!(
+        !output.status.success(),
+        "machina should reject -gdb stdio; got success exit",
+    );
+
+    let stderr = String::from_utf8_lossy(&output.stderr);
+    assert!(
+        stderr.contains("-gdb: stdio transport is not implemented"),
+        "expected stdio-not-implemented error in stderr; got: {stderr}",
+    );
+    assert!(
+        !stderr.contains("machina: gdb on stdio"),
+        "must not announce a gdb server that never starts; got: {stderr}",
+    );
+    assert!(
+        !stderr.contains("panicked at"),
+        "expected friendly error, not panic; got: {stderr}",
+    );
+}
+
+#[test]
+fn gdb_unsupported_transport_is_rejected() {
+    ensure_machina_built();
+
+    let output = Command::new(machina_bin())
+        .args(["-gdb", "pipe:nope"])
+        .output()
+        .expect("failed to spawn machina");
+
+    assert!(
+        !output.status.success(),
+        "machina should reject unknown -gdb transports",
+    );
+
+    let stderr = String::from_utf8_lossy(&output.stderr);
+    assert!(
+        stderr.contains("-gdb: unsupported"),
+        "expected unsupported-transport error; got: {stderr}",
+    );
+}

--- a/tests/src/lib.rs
+++ b/tests/src/lib.rs
@@ -9,6 +9,8 @@ mod cli_bios;
 #[cfg(test)]
 mod cli_drive;
 #[cfg(test)]
+mod cli_gdb;
+#[cfg(test)]
 mod cli_help;
 #[cfg(test)]
 mod cli_initrd;


### PR DESCRIPTION
## Summary

Closes #76. Reject `-gdb stdio` at parse time with a clear message,
since the gdb server thread only wires up `tcp:` transports today and
silently dropped stdio requests while still announcing `gdb on stdio`.

- `src/main.rs`: in the `-gdb` arm of `parse_args()`, return
  `-gdb: stdio transport is not implemented; use -gdb tcp:<host>:<port>`
  for `stdio`, and continue to reject other unknown transports.
- `tests/src/cli_gdb.rs`: assert the stdio path produces the new error
  with no `gdb on stdio` line in stderr, and that `pipe:nope` still
  reports the existing `unsupported` error.

## Test plan

- [x] `cargo fmt --all --check`
- [x] `cargo clippy --workspace -- -D warnings -A clippy::pedantic -A clippy::nursery`
- [x] `cargo test -p machina-tests --lib cli_gdb`