### PR TITLE
cli: warn when -device is ignored or unsupported (#85)

### DIFF
--- a/src/main.rs
+++ b/src/main.rs
@@ -302,7 +302,29 @@ fn parse_args() -> Result<CliArgs, String> {
                     i += 1;
                     continue;
                 }
+                // On non-Unix hosts virtio-net-device has no backend;
+                // give a specific reason rather than the generic
+                // unsupported-device error below (#85). Match the exact
+                // class only, so unknown names like "virtio-net-device-x"
+                // still get the unsupported-device rejection.
+                #[cfg(not(unix))]
+                if val == "virtio-net-device"
+                    || val.starts_with("virtio-net-device,")
+                {
+                    return Err("-device virtio-net-device requires a Unix \
+                         host (TAP backend)"
+                        .to_string());
+                }
+                // Block devices are wired up via -drive, not -device,
+                // so the value is otherwise ignored. Warn and point at
+                // the right option instead of dropping it silently
+                // (#85).
                 if val.starts_with("virtio-blk-device") {
+                    eprintln!(
+                        "machina: warning: -device virtio-blk-device \
+                         is ignored; configure block devices via \
+                         -drive file=<path>"
+                    );
                     i += 1;
                     continue;
                 }

--- a/tests/src/cli_device.rs
+++ b/tests/src/cli_device.rs
@@ -1,0 +1,88 @@
+//! Regression tests for #85: recognised-but-ignored `-device` values
+//! used to be dropped without feedback. `virtio-blk-device` is wired
+//! up via `-drive`, so machina now warns and points at the right
+//! option instead of silently ignoring it, while genuinely unknown
+//! device classes are still rejected outright.
+
+use std::path::PathBuf;
+use std::process::Command;
+use std::sync::{Mutex, OnceLock};
+
+fn project_root() -> PathBuf {
+    PathBuf::from(env!("CARGO_MANIFEST_DIR")).join("..")
+}
+
+fn machina_bin() -> PathBuf {
+    let base = project_root().join("target").join("debug").join("machina");
+    if cfg!(windows) {
+        base.with_extension("exe")
+    } else {
+        base
+    }
+}
+
+fn ensure_machina_built() {
+    // Serialise concurrent builds: on Windows multiple linkers cannot
+    // write the same .exe simultaneously.
+    static LOCK: OnceLock<Mutex<()>> = OnceLock::new();
+    let _guard = LOCK.get_or_init(Mutex::default).lock().unwrap();
+
+    let status = Command::new("cargo")
+        .args(["build", "-p", "machina-emu"])
+        .current_dir(project_root())
+        .status()
+        .expect("cargo build machina-emu failed");
+    assert!(status.success(), "cargo build machina-emu failed");
+}
+
+/// Pair the device under test with a sentinel `-kernel` arg that fails
+/// fast, so machina never boots but warnings still land in stderr.
+fn run_with_device(value: &str) -> String {
+    ensure_machina_built();
+
+    let output = Command::new(machina_bin())
+        .args(["-device", value, "-kernel", "/no/such/kernel.img"])
+        .output()
+        .expect("failed to spawn machina");
+
+    String::from_utf8_lossy(&output.stderr).into_owned()
+}
+
+#[test]
+fn virtio_blk_device_hints_at_drive() {
+    let stderr = run_with_device("virtio-blk-device,drive=hd0");
+    assert!(
+        stderr.contains("warning")
+            && stderr.contains("virtio-blk-device")
+            && stderr.contains("-drive"),
+        "expected -drive hint for virtio-blk-device; got: {stderr}",
+    );
+    assert!(
+        !stderr.contains("panicked at"),
+        "expected friendly warning, not panic; got: {stderr}",
+    );
+}
+
+#[test]
+fn unknown_device_class_is_rejected() {
+    let stderr = run_with_device("nonexistent-device-xyz");
+    assert!(
+        stderr.contains("unsupported device")
+            && stderr.contains("nonexistent-device-xyz"),
+        "expected unsupported-device error naming the class; got: \
+         {stderr}",
+    );
+}
+
+#[cfg(unix)]
+#[test]
+fn virtio_net_device_recognised_on_unix() {
+    // virtio-net-device is a recognised class on Unix: it must not be
+    // reported as unsupported nor confused with the block-device path.
+    let stderr = run_with_device("virtio-net-device,netdev=net0");
+    assert!(
+        !stderr.contains("unsupported device")
+            && !stderr.contains("warning: -device virtio-blk"),
+        "Unix host should recognise virtio-net-device; got: {stderr}",
+    );
+}

--- a/tests/src/lib.rs
+++ b/tests/src/lib.rs
@@ -7,6 +7,8 @@ mod backend;
 #[cfg(test)]
 mod cli_bios;
 #[cfg(test)]
+mod cli_device;
+#[cfg(test)]
 mod cli_drive;
 #[cfg(test)]
 mod cli_gdb;


### PR DESCRIPTION
## Summary

Closes #85. Upstream now hard-rejects genuinely unknown `-device`
values, but two *recognised* classes still gave no feedback when machina
could not honour them:

- `-device virtio-blk-device,...` was accepted and silently dropped
  (block devices are configured via `-drive`).
- On non-Unix hosts `-device virtio-net-device` fell through to the
  generic `unsupported device` error, hiding the real reason (the TAP
  backend is POSIX-only).

This reopens #120 with a narrower change that **complements** upstream's
hard-reject rather than replacing it with the original warn-everything
approach.

## Changes

- `src/main.rs`: warn and point at `-drive` when `virtio-blk-device` is
  passed via `-device`; return a specific error for `virtio-net-device`
  on non-Unix hosts. Genuinely unknown device classes keep the existing
  hard rejection.
- `tests/src/cli_device.rs`: cover the `-drive` hint, the unknown-class
  rejection, and that `virtio-net-device` stays recognised on Unix.

## Test plan

- [x] `cargo fmt --all -- --check`
- [x] `cargo build -p machina-emu`
- [x] `cargo test -p machina-tests --lib cli_device` (3 passed)
