### PR TITLE
cli: warn on unsupported -drive suboptions (#78)

### DIFF
--- a/src/main.rs
+++ b/src/main.rs
@@ -242,12 +242,23 @@ fn parse_args() -> Result<CliArgs, String> {
             "-drive" => {
                 i += 1;
                 let s = args.get(i).ok_or("-drive requires argument")?;
-                // Parse file=<path> from the option
-                // string (ignore if=, format=, id=).
+                // Only file=<path> is honoured today. Warn on every
+                // other suboption so users do not silently get a raw
+                // image when they asked for, say, format=qcow2.
                 let mut path = None;
                 for part in s.split(',') {
+                    if part.is_empty() {
+                        continue;
+                    }
                     if let Some(p) = part.strip_prefix("file=") {
                         path = Some(p.to_string());
+                    } else {
+                        let key = part.split('=').next().unwrap_or(part);
+                        eprintln!(
+                            "machina: warning: -drive {}: suboption is \
+                             not implemented; ignoring",
+                            key,
+                        );
                     }
                 }
                 cli.drive = path.map(PathBuf::from);

--- a/tests/src/cli_drive.rs
+++ b/tests/src/cli_drive.rs
@@ -1,0 +1,91 @@
+//! Regression tests for #78: `-drive` only honours `file=<path>`, but
+//! other suboptions such as `format=qcow2`, `id=disk0`, and `if=none`
+//! used to be silently dropped. Now machina emits a warning for each
+//! unsupported suboption so the user knows the request had no effect.
+
+use std::path::PathBuf;
+use std::process::Command;
+use std::sync::{Mutex, OnceLock};
+
+fn project_root() -> PathBuf {
+    PathBuf::from(env!("CARGO_MANIFEST_DIR")).join("..")
+}
+
+fn machina_bin() -> PathBuf {
+    let base = project_root().join("target").join("debug").join("machina");
+    if cfg!(windows) {
+        base.with_extension("exe")
+    } else {
+        base
+    }
+}
+
+fn ensure_machina_built() {
+    // Serialise concurrent builds: on Windows multiple linkers cannot
+    // write the same .exe simultaneously.
+    static LOCK: OnceLock<Mutex<()>> = OnceLock::new();
+    let _guard = LOCK.get_or_init(Mutex::default).lock().unwrap();
+
+    let status = Command::new("cargo")
+        .args(["build", "-p", "machina-emu"])
+        .current_dir(project_root())
+        .status()
+        .expect("cargo build machina-emu failed");
+    assert!(status.success(), "cargo build machina-emu failed");
+}
+
+/// Pair the `-drive` value with a sentinel `-kernel` arg that fails
+/// parse fast, so machina never tries to boot but warnings still land
+/// in stderr.
+fn run_with_drive(value: &str) -> String {
+    ensure_machina_built();
+
+    let output = Command::new(machina_bin())
+        .args(["-drive", value, "-kernel", "/no/such/kernel.img"])
+        .output()
+        .expect("failed to spawn machina");
+
+    String::from_utf8_lossy(&output.stderr).into_owned()
+}
+
+#[test]
+fn drive_format_suboption_warns() {
+    let stderr = run_with_drive("file=disk.img,format=qcow2");
+    assert!(
+        stderr.contains("warning") && stderr.contains("-drive format"),
+        "expected warning naming format=; got: {stderr}",
+    );
+    assert!(
+        stderr.contains("not implemented"),
+        "expected 'not implemented' wording; got: {stderr}",
+    );
+}
+
+#[test]
+fn drive_multiple_unknown_suboptions_each_warn() {
+    let stderr = run_with_drive("file=disk.img,format=qcow2,id=disk0,if=none");
+    for key in ["format", "id", "if"] {
+        assert!(
+            stderr.contains(&format!("-drive {key}")),
+            "expected per-suboption warning for {key}; got: {stderr}",
+        );
+    }
+}
+
+#[test]
+fn drive_file_only_does_not_warn() {
+    let stderr = run_with_drive("file=disk.img");
+    assert!(
+        !stderr.contains("-drive ") || !stderr.contains("not implemented"),
+        "file-only -drive should not warn; got: {stderr}",
+    );
+}
+
+#[test]
+fn drive_missing_file_is_rejected() {
+    let stderr = run_with_drive("format=qcow2,id=disk0");
+    assert!(
+        stderr.contains("-drive: missing file=<path>"),
+        "expected missing-file error; got: {stderr}",
+    );
+}

--- a/tests/src/lib.rs
+++ b/tests/src/lib.rs
@@ -7,6 +7,8 @@ mod backend;
 #[cfg(test)]
 mod cli_bios;
 #[cfg(test)]
+mod cli_drive;
+#[cfg(test)]
 mod cli_help;
 #[cfg(test)]
 mod cli_initrd;


### PR DESCRIPTION
## Summary

Closes #78. The `-drive` parser only honours `file=<path>` today, but
`format=qcow2`, `id=disk0`, `if=none` and similar suboptions used to be
silently dropped. A user could pass `-drive file=disk.img,format=qcow2`
believing the QCOW2 format was applied even though machina was reading
the file as a raw image. Now each unsupported suboption produces a
warning naming the key.

- `src/main.rs`: split the `-drive` suboption walk so anything that is
  not `file=` emits `machina: warning: -drive <key>: suboption is not
  implemented; ignoring`.
- `tests/src/cli_drive.rs`: cover the `format=` warning, the multi-key
  case (each suboption warned once), the file-only happy path (no
  warning), and the existing missing-`file=` rejection.

## Test plan

- [x] `cargo fmt --all --check`
- [x] `cargo clippy --workspace -- -D warnings -A clippy::pedantic -A clippy::nursery`
- [x] `cargo test -p machina-tests --lib cli_drive`