### PR TITLE
cli: add Examples section to usage() output (#86)

### DIFF
--- a/src/main.rs
+++ b/src/main.rs
@@ -83,6 +83,18 @@ fn usage() {
     );
     eprintln!("  --trace file  Trace output file");
     eprintln!("  -h, --help    Show this help");
+    eprintln!();
+    eprintln!("Examples:");
+    eprintln!("  Boot a kernel with the built-in SBI firmware:");
+    eprintln!("    machina -bios builtin -kernel vmlinux");
+    eprintln!();
+    eprintln!("  Boot with a virtio block disk and TAP networking:");
+    eprintln!("    machina -kernel vmlinux -drive file=rootfs.img \\");
+    eprintln!("      -netdev tap,id=net0,ifname=tap0 \\");
+    eprintln!("      -device virtio-net-device,netdev=net0");
+    eprintln!();
+    eprintln!("  Pause at startup and wait for a GDB client on tcp::1234:");
+    eprintln!("    machina -kernel vmlinux -s -S");
 }
 
 struct CliArgs {

--- a/tests/src/cli_help.rs
+++ b/tests/src/cli_help.rs
@@ -1,0 +1,83 @@
+//! Regression tests for #86: `machina -h` / `--help` should include
+//! an Examples section so new users can see how to combine options to
+//! start a complete emulation environment.
+
+use std::path::PathBuf;
+use std::process::Command;
+use std::sync::{Mutex, OnceLock};
+
+fn project_root() -> PathBuf {
+    PathBuf::from(env!("CARGO_MANIFEST_DIR")).join("..")
+}
+
+fn machina_bin() -> PathBuf {
+    let base = project_root().join("target").join("debug").join("machina");
+    if cfg!(windows) {
+        base.with_extension("exe")
+    } else {
+        base
+    }
+}
+
+fn ensure_machina_built() {
+    // Serialise concurrent builds: on Windows multiple linkers cannot
+    // write the same .exe simultaneously.
+    static LOCK: OnceLock<Mutex<()>> = OnceLock::new();
+    let _guard = LOCK.get_or_init(Mutex::default).lock().unwrap();
+
+    let status = Command::new("cargo")
+        .args(["build", "-p", "machina-emu"])
+        .current_dir(project_root())
+        .status()
+        .expect("cargo build machina-emu failed");
+    assert!(status.success(), "cargo build machina-emu failed");
+}
+
+fn run_help(flag: &str) -> String {
+    ensure_machina_built();
+    let output = Command::new(machina_bin())
+        .arg(flag)
+        .output()
+        .expect("failed to spawn machina");
+    assert!(
+        output.status.success(),
+        "{flag} should exit 0; got {:?}",
+        output.status,
+    );
+    String::from_utf8_lossy(&output.stderr).into_owned()
+}
+
+#[test]
+fn help_short_flag_includes_examples_section() {
+    let stderr = run_help("-h");
+    assert!(
+        stderr.contains("Examples:"),
+        "expected an Examples section in -h output; got: {stderr}",
+    );
+}
+
+#[test]
+fn help_long_flag_includes_examples_section() {
+    let stderr = run_help("--help");
+    assert!(
+        stderr.contains("Examples:"),
+        "expected an Examples section in --help output; got: {stderr}",
+    );
+}
+
+#[test]
+fn help_examples_cover_built_in_sbi_disk_network_and_gdb() {
+    let stderr = run_help("--help");
+    for snippet in [
+        "machina -bios builtin -kernel vmlinux",
+        "-drive file=rootfs.img",
+        "-netdev tap,id=net0,ifname=tap0",
+        "-device virtio-net-device,netdev=net0",
+        "machina -kernel vmlinux -s -S",
+    ] {
+        assert!(
+            stderr.contains(snippet),
+            "expected example to contain `{snippet}`; got: {stderr}",
+        );
+    }
+}

--- a/tests/src/lib.rs
+++ b/tests/src/lib.rs
@@ -5,6 +5,8 @@ mod arch_exit;
 #[cfg(test)]
 mod backend;
 #[cfg(test)]
+mod cli_help;
+#[cfg(test)]
 mod cli_initrd;
 #[cfg(test)]
 mod cli_kernel;


### PR DESCRIPTION
## Summary

Closes #86. Append a worked-example block to `usage()` so new users can
see how options compose into a full invocation, instead of just
reading a flat option list.

- `src/main.rs`: extend `usage()` with three examples covering minimal
  boot with the built-in SBI firmware, boot with a virtio block disk
  plus a TAP network device, and pause-at-startup for a GDB client.
  The networking example is split across continuation lines the way
  a shell user would type it (trailing `\\`).
- `tests/src/cli_help.rs`: spawn `machina -h` and `machina --help`,
  assert the new `Examples:` header is present and that the three
  example invocations contain the key option strings.

## Test plan

- [x] `cargo fmt --all --check`
- [x] `cargo clippy --workspace -- -D warnings -A clippy::pedantic -A clippy::nursery`
- [x] `cargo test -p machina-tests --lib cli_help`
- [x] visual check: `./target/debug/machina --help`