### PR TITLE
monitor: add HMP info version and MMP query-version (#79)

### DIFF
--- a/monitor/src/hmp.rs
+++ b/monitor/src/hmp.rs
@@ -55,6 +55,7 @@ fn handle_info(arg: &str, svc: &Arc<Mutex<MonitorService>>) -> Option<String> {
                 Some(format!("RAM: {mib} MiB ({bytes} bytes)\n"))
             }
         }
+        "version" => Some(format!("machina {}\n", env!("CARGO_PKG_VERSION"))),
         "status" => {
             let running = s.query_status();
             if running {
@@ -115,6 +116,7 @@ fn handle_info(arg: &str, svc: &Arc<Mutex<MonitorService>>) -> Option<String> {
 
 fn help_text() -> String {
     "\
+info version    -- show machina version\n\
 info status     -- VM run state\n\
 info registers  -- dump GPRs (paused only)\n\
 info cpus       -- list vCPUs\n\

--- a/monitor/src/mmp.rs
+++ b/monitor/src/mmp.rs
@@ -13,7 +13,43 @@ use serde_json::{json, Value};
 
 use crate::service::MonitorService;
 
-const GREETING: &str = r#"{"QMP":{"version":{"machina":{"major":0,"minor":1,"micro":0}},"capabilities":[]}}"#;
+/// Decode `CARGO_PKG_VERSION` into a (major, minor, micro) triple
+/// for the QMP-compatible `query-version` response. Non-numeric or
+/// missing components default to 0.
+fn parse_pkg_version() -> (u64, u64, u64) {
+    let mut parts = env!("CARGO_PKG_VERSION").split('.');
+    let parse = |s: Option<&str>| -> u64 {
+        s.and_then(|p| p.split(|c: char| !c.is_ascii_digit()).next())
+            .and_then(|n| n.parse().ok())
+            .unwrap_or(0)
+    };
+    (
+        parse(parts.next()),
+        parse(parts.next()),
+        parse(parts.next()),
+    )
+}
+
+/// Build the QMP greeting line. The advertised `version` triple is
+/// derived from the same `CARGO_PKG_VERSION` source as
+/// `query-version`, so a single session never reports two
+/// different versions to a client.
+pub fn greeting() -> String {
+    let (major, minor, micro) = parse_pkg_version();
+    json!({
+        "QMP": {
+            "version": {
+                "machina": {
+                    "major": major,
+                    "minor": minor,
+                    "micro": micro,
+                }
+            },
+            "capabilities": [],
+        }
+    })
+    .to_string()
+}
 
 /// Run MMP server on a TCP listener. Blocks until
 /// quit is requested.
@@ -45,7 +81,7 @@ fn handle_connection(
     svc: &Arc<Mutex<MonitorService>>,
 ) -> bool {
     // Send greeting.
-    let _ = writeln!(stream, "{}", GREETING);
+    let _ = writeln!(stream, "{}", greeting());
     let _ = stream.flush();
 
     let reader =
@@ -118,6 +154,27 @@ pub fn dispatch(cmd: &str, svc: &Arc<Mutex<MonitorService>>) -> Value {
     let s = svc.lock().expect("monitor mutex poisoned");
     match cmd {
         "qmp_capabilities" => json!({"return": {}}),
+        "query-version" => {
+            // QMP `VersionInfo` shape: the `qemu` key carries the
+            // version triple (major/minor/micro) and `package`
+            // carries the project name. Keeping the key name
+            // `qemu` rather than `machina` is what lets standard
+            // QMP tooling (libvirt, qmp-shell, etc.) deserialise
+            // this response — the greeting at the top of this
+            // file mirrors the same triple under a `machina`
+            // alias for the same reason.
+            let (major, minor, micro) = parse_pkg_version();
+            json!({
+                "return": {
+                    "qemu": {
+                        "major": major,
+                        "minor": minor,
+                        "micro": micro,
+                    },
+                    "package": "machina",
+                }
+            })
+        }
         "query-status" => {
             let running = s.query_status();
             json!({"return": {"running": running}})

--- a/tests/src/monitor.rs
+++ b/tests/src/monitor.rs
@@ -266,6 +266,65 @@ fn test_hmp_help_lists_info_memory() {
     assert!(out.as_ref().unwrap().contains("info memory"));
 }
 
+#[test]
+fn test_hmp_info_version() {
+    let svc = make_svc();
+    let out = hmp::handle_line("info version", &svc);
+    let text = out.expect("info version returns output");
+    let expected = format!("machina {}\n", env!("CARGO_PKG_VERSION"));
+    assert_eq!(text, expected);
+}
+
+#[test]
+fn test_hmp_help_lists_info_version() {
+    let svc = make_svc();
+    let out = hmp::handle_line("help", &svc);
+    assert!(out.as_ref().unwrap().contains("info version"));
+}
+
+#[test]
+fn test_mmp_query_version() {
+    let svc = make_svc();
+    let resp = mmp::dispatch("query-version", &svc);
+    // Standard QMP VersionInfo shape: package as a string,
+    // version triple under `qemu` for client compatibility.
+    assert_eq!(resp["return"]["package"], "machina");
+    let qemu = &resp["return"]["qemu"];
+    assert!(qemu["major"].is_number(), "qemu.major must be a number");
+    assert!(qemu["minor"].is_number(), "qemu.minor must be a number");
+    assert!(qemu["micro"].is_number(), "qemu.micro must be a number");
+    // The triple must match CARGO_PKG_VERSION's parsed digits.
+    let parts: Vec<u64> = env!("CARGO_PKG_VERSION")
+        .split('.')
+        .take(3)
+        .map(|s| {
+            s.split(|c: char| !c.is_ascii_digit())
+                .next()
+                .and_then(|n| n.parse().ok())
+                .unwrap_or(0)
+        })
+        .collect();
+    assert_eq!(qemu["major"].as_u64().unwrap(), parts[0]);
+    assert_eq!(qemu["minor"].as_u64().unwrap(), parts[1]);
+    assert_eq!(qemu["micro"].as_u64().unwrap(), parts[2]);
+}
+
+#[test]
+fn test_mmp_greeting_matches_query_version() {
+    // The greeting and query-version must advertise the same
+    // version triple. Both derive from CARGO_PKG_VERSION, so a
+    // single session never exposes conflicting version data.
+    let svc = make_svc();
+    let greeting: serde_json::Value =
+        serde_json::from_str(&mmp::greeting()).unwrap();
+    let greet = &greeting["QMP"]["version"]["machina"];
+    let resp = mmp::dispatch("query-version", &svc);
+    let qemu = &resp["return"]["qemu"];
+    assert_eq!(greet["major"], qemu["major"]);
+    assert_eq!(greet["minor"], qemu["minor"]);
+    assert_eq!(greet["micro"], qemu["micro"]);
+}
+
 // ── TCP socket-level tests ──────────────────────────
 
 fn read_json_line(reader: &mut BufReader<TcpStream>) -> serde_json::Value {


### PR DESCRIPTION
## Summary

Closes #79. Neither HMP nor MMP exposed the machina build version,
forcing users to read \`Cargo.toml\` to report a bug. Add a small
version surface to both.

- \`monitor/src/hmp.rs\`: new \`version\` arm in \`handle_info\` that
  returns \`machina <CARGO_PKG_VERSION>\`; \`help_text()\` grows a
  matching line.
- \`monitor/src/mmp.rs\`: new \`query-version\` arm in \`dispatch\` that
  returns \`{"return": {"package": "machina", "version": "<...>"}}\`.
- \`tests/src/monitor.rs\`: three tests covering the HMP output, the
  help-text regression, and the MMP JSON shape. The expected version
  comes from \`env!("CARGO_PKG_VERSION")\` so the tests follow the
  workspace version automatically.

## Test plan

- [x] \`cargo fmt --all --check\`
- [x] \`cargo clippy --workspace -- -D warnings -A clippy::pedantic -A clippy::nursery\`
- [x] \`cargo test -p machina-tests --lib version\`