### PR TITLE
monitor: implement MMP system_powerdown (#88)

### DIFF
--- a/monitor/src/mmp.rs
+++ b/monitor/src/mmp.rs
@@ -101,7 +101,12 @@ fn handle_connection(
         if cmd == "qmp_capabilities" {
             caps_done = true;
         }
-        if cmd == "quit" {
+        // Both quit and its QMP alias system_powerdown must end the
+        // connection loop. Without this the dispatch arm flips
+        // quit_requested but reader.lines() keeps blocking, so a
+        // peer that holds the socket open after system_powerdown
+        // leaves the monitor thread parked indefinitely.
+        if cmd == "quit" || cmd == "system_powerdown" {
             return true;
         }
     }
@@ -127,6 +132,12 @@ pub fn dispatch(cmd: &str, svc: &Arc<Mutex<MonitorService>>) -> Value {
             json!({"return": {}})
         }
         "quit" => {
+            s.quit();
+            json!({"return": {}})
+        }
+        "system_powerdown" => {
+            // QMP-compatible alias for quit: request shutdown so the
+            // emulator exits cleanly.
             s.quit();
             json!({"return": {}})
         }

--- a/tests/src/monitor.rs
+++ b/tests/src/monitor.rs
@@ -137,6 +137,61 @@ fn test_mmp_quit() {
     assert!(svc.lock().unwrap().state.is_quit_requested());
 }
 
+#[test]
+fn test_mmp_system_powerdown() {
+    let svc = make_svc();
+    let resp = mmp::dispatch("system_powerdown", &svc);
+    assert_eq!(resp["return"], serde_json::json!({}));
+    assert!(
+        svc.lock().unwrap().state.is_quit_requested(),
+        "system_powerdown must request shutdown",
+    );
+}
+
+#[test]
+fn test_tcp_system_powerdown_terminates_connection_loop() {
+    // Regression: codex flagged that system_powerdown was an alias
+    // of quit at dispatch level but handle_connection only exited
+    // when cmd == "quit", so a peer could send system_powerdown,
+    // get success, and leave the monitor thread parked in
+    // reader.lines(). The fix makes both commands end the loop;
+    // this test asserts the spawned run_tcp thread joins cleanly
+    // after a single system_powerdown round-trip.
+    if !tcp_bind_available() {
+        eprintln!("skipping: TCP bind not permitted");
+        return;
+    }
+    let state = Arc::new(MonitorState::new());
+    let svc = Arc::new(Mutex::new(MonitorService::new(Arc::clone(&state))));
+    let listener = std::net::TcpListener::bind("127.0.0.1:0").unwrap();
+    let addr = listener.local_addr().unwrap();
+
+    let svc2 = Arc::clone(&svc);
+    let handle = std::thread::spawn(move || mmp::run_tcp(listener, svc2));
+
+    let stream = TcpStream::connect(addr).unwrap();
+    stream
+        .set_read_timeout(Some(std::time::Duration::from_secs(3)))
+        .unwrap();
+    let mut reader = BufReader::new(stream.try_clone().unwrap());
+    let mut writer = stream;
+
+    let _greeting = read_json_line(&mut reader);
+    send_cmd(&mut writer, "qmp_capabilities");
+    let _ = read_json_line(&mut reader);
+
+    send_cmd(&mut writer, "system_powerdown");
+    let resp = read_json_line(&mut reader);
+    assert!(
+        resp["return"].is_object(),
+        "system_powerdown should ack with empty return: {resp}",
+    );
+
+    // The server thread must terminate without us sending quit.
+    handle.join().unwrap();
+    assert!(state.is_quit_requested());
+}
+
 // ── HMP tests ───────────────────────────────────────
 
 #[test]


### PR DESCRIPTION
## Summary

Closes #88. The MMP dispatcher previously had no `system_powerdown`
arm, so QMP clients accustomed to QEMU saw `CommandNotFound` and had
to use the machina-specific `quit`. Reuse the existing shutdown path
so `system_powerdown` works as a QMP-compatible alias.

- `monitor/src/mmp.rs`: new `system_powerdown` arm that calls
  `s.quit()` and returns `{"return": {}}`.
- `tests/src/monitor.rs`: new `test_mmp_system_powerdown` asserting
  both the response shape and that quit was actually requested on the
  underlying state.

## Test plan

- [x] `cargo fmt --all --check`
- [x] `cargo clippy --workspace -- -D warnings -A clippy::pedantic -A clippy::nursery`
- [x] `cargo test -p machina-tests --lib system_powerdown`