### PR TITLE
monitor: add HMP info memory command (#87)

### DIFF
--- a/monitor/src/hmp.rs
+++ b/monitor/src/hmp.rs
@@ -46,6 +46,15 @@ pub fn handle_line(
 fn handle_info(arg: &str, svc: &Arc<Mutex<MonitorService>>) -> Option<String> {
     let s = svc.lock().expect("monitor mutex poisoned");
     match arg.trim() {
+        "memory" => {
+            let bytes = s.ram_size();
+            if bytes == 0 {
+                Some("RAM: not configured\n".into())
+            } else {
+                let mib = bytes / (1024 * 1024);
+                Some(format!("RAM: {mib} MiB ({bytes} bytes)\n"))
+            }
+        }
         "status" => {
             let running = s.query_status();
             if running {
@@ -109,6 +118,7 @@ fn help_text() -> String {
 info status     -- VM run state\n\
 info registers  -- dump GPRs (paused only)\n\
 info cpus       -- list vCPUs\n\
+info memory     -- show guest RAM size\n\
 stop            -- pause vCPU\n\
 cont (c)        -- resume vCPU\n\
 quit (q)        -- exit emulator\n\

--- a/monitor/src/service.rs
+++ b/monitor/src/service.rs
@@ -7,11 +7,30 @@ use machina_core::monitor::{CpuSnapshot, MonitorState, VmState};
 /// Central monitor service shared by all transports.
 pub struct MonitorService {
     pub state: Arc<MonitorState>,
+    /// Total guest RAM in bytes, populated by `main.rs` after CLI
+    /// parsing and read by `info memory` / `query-memory`. `0` until
+    /// it is explicitly set, which is the case in unit tests that do
+    /// not exercise memory-aware commands.
+    ram_size_bytes: u64,
 }
 
 impl MonitorService {
     pub fn new(state: Arc<MonitorState>) -> Self {
-        Self { state }
+        Self {
+            state,
+            ram_size_bytes: 0,
+        }
+    }
+
+    /// Record the guest RAM size in bytes so the monitor can report
+    /// it through `info memory`.
+    pub fn set_ram_size(&mut self, bytes: u64) {
+        self.ram_size_bytes = bytes;
+    }
+
+    /// Guest RAM size in bytes as last set by `set_ram_size`.
+    pub fn ram_size(&self) -> u64 {
+        self.ram_size_bytes
     }
 
     pub fn query_status(&self) -> bool {

--- a/src/main.rs
+++ b/src/main.rs
@@ -779,6 +779,10 @@ fn main() {
             &monitor_state,
         )),
     ));
+    monitor_svc
+        .lock()
+        .expect("monitor mutex poisoned")
+        .set_ram_size(ram_size);
 
     // Start monitor transport thread (if configured).
     if let Some(ref mon) = cli.monitor {

--- a/tests/src/monitor.rs
+++ b/tests/src/monitor.rs
@@ -189,6 +189,28 @@ fn test_hmp_info_cpus() {
     assert!(out.as_ref().unwrap().contains("CPU #0"));
 }
 
+#[test]
+fn test_hmp_info_memory_unconfigured() {
+    let svc = make_svc();
+    let out = hmp::handle_line("info memory", &svc);
+    assert_eq!(out, Some("RAM: not configured\n".to_string()));
+}
+
+#[test]
+fn test_hmp_info_memory_reports_mib_and_bytes() {
+    let svc = make_svc();
+    svc.lock().unwrap().set_ram_size(128 * 1024 * 1024);
+    let out = hmp::handle_line("info memory", &svc);
+    assert_eq!(out, Some("RAM: 128 MiB (134217728 bytes)\n".to_string()),);
+}
+
+#[test]
+fn test_hmp_help_lists_info_memory() {
+    let svc = make_svc();
+    let out = hmp::handle_line("help", &svc);
+    assert!(out.as_ref().unwrap().contains("info memory"));
+}
+
 // ── TCP socket-level tests ──────────────────────────
 
 fn read_json_line(reader: &mut BufReader<TcpStream>) -> serde_json::Value {


### PR DESCRIPTION
## Summary

Closes #87. Surface guest RAM size through the HMP `info` namespace so
users can quickly check the running configuration without grepping
the boot banner.

- `monitor/src/service.rs`: add a private `ram_size_bytes` field on
  `MonitorService`, plus `set_ram_size(&mut self, bytes)` and
  `ram_size(&self) -> u64`. Default is `0`; existing callers and unit
  tests that do not exercise memory commands stay unchanged.
- `monitor/src/hmp.rs`: new `memory` arm in `handle_info` that prints
  `RAM: <mib> MiB (<bytes> bytes)`, with a `RAM: not configured`
  fallback when the field is still zero. `help_text()` grows a
  matching line.
- `src/main.rs`: lock the monitor service once after construction and
  publish the post-parse `ram_size`.

Tests in `tests/src/monitor.rs`: unconfigured fallback, populated
128 MiB case, and a help-text regression for the new line.

## Test plan

- [x] `cargo fmt --all --check`
- [x] `cargo clippy --workspace -- -D warnings -A clippy::pedantic -A clippy::nursery`
- [x] `cargo test -p machina-tests --lib info_memory`
- [x] `cargo test -p machina-tests --lib test_hmp_help_lists_info_memory`