### PR TITLE
tools: return friendly errors from IR tool argv parsing (#55)

### DIFF
--- a/tests/src/tools/mod.rs
+++ b/tests/src/tools/mod.rs
@@ -142,6 +142,119 @@ fn irbackend_raw_output() {
     let _ = fs::remove_file(&tmp_bin);
 }
 
+/// Spawn one of the IR tools with a single dummy positional plus the
+/// supplied option set, capturing stdout+stderr. Used by the
+/// friendly-error tests below: the tools must reject malformed input
+/// with a non-zero exit and a clear message, never with a panic.
+fn run_tool_args(name: &str, extra_args: &[&str]) -> (bool, String) {
+    ensure_built();
+    let mut cmd = Command::new(bin_path(name));
+    cmd.arg("dummy.elf");
+    cmd.args(extra_args);
+    let out = cmd.output().expect("failed to spawn tool");
+    let combined = format!(
+        "{}{}",
+        String::from_utf8_lossy(&out.stdout),
+        String::from_utf8_lossy(&out.stderr),
+    );
+    (out.status.success(), combined)
+}
+
+fn assert_friendly_error(name: &str, args: &[&str], must_contain: &[&str]) {
+    let (success, combined) = run_tool_args(name, args);
+    assert!(
+        !success,
+        "{name} must reject {args:?}; got success exit\n{combined}",
+    );
+    assert!(
+        !combined.contains("panicked at"),
+        "{name} must not panic on {args:?}\n{combined}",
+    );
+    for needle in must_contain {
+        assert!(
+            combined.contains(needle),
+            "{name} {args:?}: expected `{needle}` in output\n{combined}",
+        );
+    }
+}
+
+#[test]
+fn irdump_missing_value_for_arch_is_friendly() {
+    assert_friendly_error(
+        "machina-irdump",
+        &["--arch"],
+        &["--arch requires argument"],
+    );
+}
+
+#[test]
+fn irdump_missing_value_for_output_is_friendly() {
+    assert_friendly_error("machina-irdump", &["-o"], &["-o requires argument"]);
+}
+
+#[test]
+fn irdump_missing_value_for_emit_bin_is_friendly() {
+    assert_friendly_error(
+        "machina-irdump",
+        &["--emit-bin"],
+        &["--emit-bin requires argument"],
+    );
+}
+
+#[test]
+fn irdump_invalid_count_is_friendly() {
+    assert_friendly_error(
+        "machina-irdump",
+        &["--count", "not-a-number"],
+        &["invalid --count", "not-a-number"],
+    );
+}
+
+#[test]
+fn irdump_invalid_start_is_friendly() {
+    assert_friendly_error(
+        "machina-irdump",
+        &["--start", "ZZZ"],
+        &["invalid --start", "ZZZ"],
+    );
+}
+
+#[test]
+fn irdump_invalid_max_insns_is_friendly() {
+    assert_friendly_error(
+        "machina-irdump",
+        &["--max-insns", "abc"],
+        &["invalid --max-insns", "abc"],
+    );
+}
+
+#[test]
+fn irdump_unknown_option_is_friendly() {
+    assert_friendly_error(
+        "machina-irdump",
+        &["--no-such-flag"],
+        &["unknown option: --no-such-flag"],
+    );
+}
+
+#[test]
+fn irbackend_missing_output_value_is_friendly() {
+    assert_friendly_error(
+        "machina-irbackend",
+        &["-o"],
+        &["-o requires argument"],
+    );
+}
+
+#[test]
+fn irbackend_unknown_option_is_friendly() {
+    assert_friendly_error(
+        "machina-irbackend",
+        &["--no-such-flag"],
+        &["unknown option: --no-such-flag"],
+    );
+}
+
 #[test]
 fn irbackend_multiple_tbs() {
     ensure_built();

--- a/tools/irbackend/src/main.rs
+++ b/tools/irbackend/src/main.rs
@@ -30,7 +30,21 @@ Options:
   --disas     Disassemble via objdump
   -h, --help  Show this help";
 
-fn parse_args() -> Args {
+/// Pull the value following `args[*i]` (the option name), advancing
+/// `*i` to point at the consumed value. Returns a friendly error
+/// instead of panicking when the value is missing.
+fn next_value<'a>(
+    args: &'a [String],
+    i: &mut usize,
+    name: &str,
+) -> Result<&'a str, String> {
+    *i += 1;
+    args.get(*i)
+        .map(String::as_str)
+        .ok_or_else(|| format!("{name} requires argument"))
+}
+
+fn parse_args() -> Result<Args, String> {
     let args: Vec<String> = env::args().collect();
     if args.len() < 2 || args[1] == "--help" || args[1] == "-h" {
         eprintln!("{USAGE}");
@@ -48,19 +62,17 @@ fn parse_args() -> Args {
     while i < args.len() {
         match args[i].as_str() {
             "-o" => {
-                i += 1;
-                a.output = Some(args[i].clone());
+                a.output = Some(next_value(&args, &mut i, "-o")?.to_string());
             }
             "--raw" => a.raw = true,
             "--disas" => a.disas = true,
             other => {
-                eprintln!("unknown option: {other}");
-                process::exit(1);
+                return Err(format!("unknown option: {other}"));
             }
         }
         i += 1;
     }
-    a
+    Ok(a)
 }
 
 fn hex_dump(data: &[u8], w: &mut impl Write) -> io::Result<()> {
@@ -96,7 +108,13 @@ fn disassemble(code: &[u8]) {
 }
 
 fn main() {
-    let args = parse_args();
+    let args = match parse_args() {
+        Ok(a) => a,
+        Err(e) => {
+            eprintln!("tcg-irbackend: {e}");
+            process::exit(1);
+        }
+    };
 
     let data = fs::read(&args.ir_path).unwrap_or_else(|e| {
         let p = &args.ir_path;

--- a/tools/irdump/src/main.rs
+++ b/tools/irdump/src/main.rs
@@ -72,7 +72,21 @@ Options:
 
 Supported architectures: riscv64";
 
-fn parse_args() -> Args {
+/// Pull the value following `args[*i]` (the option name), advancing
+/// `*i` to point at the consumed value. Returns a friendly error
+/// instead of panicking when the value is missing.
+fn next_value<'a>(
+    args: &'a [String],
+    i: &mut usize,
+    name: &str,
+) -> Result<&'a str, String> {
+    *i += 1;
+    args.get(*i)
+        .map(String::as_str)
+        .ok_or_else(|| format!("{name} requires argument"))
+}
+
+fn parse_args() -> Result<Args, String> {
     let args: Vec<String> = env::args().collect();
     if args.len() < 2 || args[1] == "--help" || args[1] == "-h" {
         eprintln!("{USAGE}");
@@ -93,40 +107,43 @@ fn parse_args() -> Args {
     while i < args.len() {
         match args[i].as_str() {
             "--arch" => {
-                i += 1;
-                a.arch = Some(args[i].clone());
+                a.arch = Some(next_value(&args, &mut i, "--arch")?.to_string());
             }
             "-o" => {
-                i += 1;
-                a.output = Some(args[i].clone());
+                a.output = Some(next_value(&args, &mut i, "-o")?.to_string());
             }
             "--emit-bin" => {
-                i += 1;
-                a.emit_bin = Some(args[i].clone());
+                a.emit_bin =
+                    Some(next_value(&args, &mut i, "--emit-bin")?.to_string());
             }
             "--start" => {
-                i += 1;
-                let s = args[i].trim_start_matches("0x");
+                let v = next_value(&args, &mut i, "--start")?;
+                let s = v.trim_start_matches("0x");
                 a.start = Some(
-                    u64::from_str_radix(s, 16).expect("invalid hex address"),
+                    u64::from_str_radix(s, 16)
+                        .map_err(|e| format!("invalid --start '{v}': {e}"))?,
                 );
             }
             "--count" => {
-                i += 1;
-                a.count = Some(args[i].parse().expect("invalid count"));
+                let v = next_value(&args, &mut i, "--count")?;
+                a.count = Some(
+                    v.parse()
+                        .map_err(|e| format!("invalid --count '{v}': {e}"))?,
+                );
             }
             "--max-insns" => {
-                i += 1;
-                a.max_insns = args[i].parse().expect("invalid max-insns");
+                let v = next_value(&args, &mut i, "--max-insns")?;
+                a.max_insns = v
+                    .parse()
+                    .map_err(|e| format!("invalid --max-insns '{v}': {e}"))?;
             }
             other => {
-                eprintln!("unknown option: {other}");
-                process::exit(1);
+                return Err(format!("unknown option: {other}"));
             }
         }
         i += 1;
     }
-    a
+    Ok(a)
 }
 
 /// Build a flat guest memory image from ELF segments.
@@ -240,7 +257,13 @@ fn translate_tb_riscv64(
 }
 
 fn main() {
-    let args = parse_args();
+    let args = match parse_args() {
+        Ok(a) => a,
+        Err(e) => {
+            eprintln!("tcg-irdump: {e}");
+            process::exit(1);
+        }
+    };
 
     let data = fs::read(&args.elf_path).unwrap_or_else(|e| {
         let p = &args.elf_path;


### PR DESCRIPTION
## Summary

Closes #55. Both `tcg-irdump` and `tcg-irbackend` used to read
positional values via `args[i].clone()` after a bare `i += 1`, so
passing an option without its value (e.g. `--arch` at the end of
argv) panicked with a Rust index-out-of-bounds backtrace. Numeric
values went through `expect()`, exposing the same backtrace style
for typos like `--count xyz`.

- `tools/irdump/src/main.rs` & `tools/irbackend/src/main.rs`:
  - new `next_value(args, &mut i, name)` helper returns
    `Err("<name> requires argument")` instead of panicking when the
    option is at the tail of argv;
  - `parse_args` now returns `Result<Args, String>`; numeric parsing
    uses `map_err` to produce messages such as
    `invalid --count 'xyz': invalid digit ...`;
  - `main` prints `tcg-irdump: <err>` / `tcg-irbackend: <err>` to
    stderr and exits with code 1.
- `tests/src/tools/mod.rs`: nine new tests (`irdump_missing_*`,
  `irdump_invalid_*`, `irdump_unknown_option`, plus
  `irbackend_missing_output_value` and `irbackend_unknown_option`)
  asserting non-zero exit, the friendly error text, the offending
  value where applicable, and the absence of `panicked at` in
  stderr.

## Test plan

- [x] `cargo fmt --all --check`
- [x] `cargo clippy --workspace -- -D warnings -A clippy::pedantic -A clippy::nursery`
- [x] `cargo test -p machina-tests --lib tools::` (all 19 pass)