### PR TITLE
softfloat: fix min/max Inf ordering and add IEEE 754 edge tests (#61)

### DIFF
--- a/softfloat/src/ops/minmax.rs
+++ b/softfloat/src/ops/minmax.rs
@@ -32,6 +32,18 @@ pub fn min<F: FloatFormat>(a: F, b: F, env: &mut FloatEnv) -> F {
         return a;
     }
 
+    // Infinities short-circuit the magnitude comparison below: the
+    // `exp` field returned by `unpack` is not meaningful for Inf, so
+    // comparing it against a finite `exp` would produce the wrong
+    // ordering. -Inf is always the smallest non-NaN value, +Inf the
+    // largest.
+    if pa.cls == FloatClass::Inf {
+        return if pa.sign { a } else { b };
+    }
+    if pb.cls == FloatClass::Inf {
+        return if pb.sign { b } else { a };
+    }
+
     // Both zeros: prefer -0.
     if pa.cls == FloatClass::Zero && pb.cls == FloatClass::Zero {
         return if pb.sign { b } else { a };
@@ -85,6 +97,18 @@ pub fn max<F: FloatFormat>(a: F, b: F, env: &mut FloatEnv) -> F {
     }
     if pb.is_nan() {
         return a;
+    }
+
+    // Infinities short-circuit the magnitude comparison below: the
+    // `exp` field returned by `unpack` is not meaningful for Inf, so
+    // comparing it against a finite `exp` would produce the wrong
+    // ordering. +Inf is always the largest non-NaN value, -Inf the
+    // smallest.
+    if pa.cls == FloatClass::Inf {
+        return if pa.sign { b } else { a };
+    }
+    if pb.cls == FloatClass::Inf {
+        return if pb.sign { a } else { b };
     }
 
     // Both zeros: prefer +0.

--- a/tests/src/softfloat/edge_cases.rs
+++ b/tests/src/softfloat/edge_cases.rs
@@ -209,3 +209,157 @@ fn f32_nan_compare_signals_invalid() {
     assert!(!nan.lt(one, &mut e));
     assert!(e.flags().contains(ExcFlags::INVALID));
 }
+
+// ── Min/Max edge cases (#61) ────────────────────────
+
+#[test]
+fn f32_min_pos_zero_neg_zero_returns_neg_zero() {
+    let mut e = env();
+    let pz = Float32::from_f32(0.0);
+    let nz = Float32::from_bits(0x8000_0000);
+    // IEEE 754-2008: min(+0, -0) = -0, regardless of operand order.
+    assert_eq!(pz.min(nz, &mut e).to_bits(), 0x8000_0000);
+    assert_eq!(nz.min(pz, &mut e).to_bits(), 0x8000_0000);
+}
+
+#[test]
+fn f32_max_pos_zero_neg_zero_returns_pos_zero() {
+    let mut e = env();
+    let pz = Float32::from_f32(0.0);
+    let nz = Float32::from_bits(0x8000_0000);
+    // IEEE 754-2008: max(+0, -0) = +0, regardless of operand order.
+    assert_eq!(pz.max(nz, &mut e).to_bits(), 0x0000_0000);
+    assert_eq!(nz.max(pz, &mut e).to_bits(), 0x0000_0000);
+}
+
+#[test]
+fn f32_min_qnan_finite_returns_finite_no_invalid() {
+    // IEEE 754-2008: min/max with one quiet NaN returns the
+    // non-NaN operand and does NOT raise INVALID.
+    let mut e = env();
+    let nan = Float32::from_bits(QNAN);
+    let one = Float32::from_f32(1.0);
+    assert_eq!(nan.min(one, &mut e).to_bits(), one.to_bits());
+    assert_eq!(one.min(nan, &mut e).to_bits(), one.to_bits());
+    assert!(
+        !e.flags().contains(ExcFlags::INVALID),
+        "qNaN must not raise INVALID for min: {:?}",
+        e.flags(),
+    );
+}
+
+#[test]
+fn f32_max_qnan_finite_returns_finite_no_invalid() {
+    let mut e = env();
+    let nan = Float32::from_bits(QNAN);
+    let one = Float32::from_f32(1.0);
+    assert_eq!(nan.max(one, &mut e).to_bits(), one.to_bits());
+    assert_eq!(one.max(nan, &mut e).to_bits(), one.to_bits());
+    assert!(
+        !e.flags().contains(ExcFlags::INVALID),
+        "qNaN must not raise INVALID for max: {:?}",
+        e.flags(),
+    );
+}
+
+#[test]
+fn f32_min_snan_finite_signals_invalid() {
+    // IEEE 754-2008: any signalling NaN operand to min/max raises
+    // INVALID. The non-NaN value is returned.
+    let mut e = env();
+    let snan = Float32::from_bits(SNAN);
+    let one = Float32::from_f32(1.0);
+    let r = snan.min(one, &mut e);
+    assert_eq!(r.to_bits(), one.to_bits());
+    assert!(
+        e.flags().contains(ExcFlags::INVALID),
+        "sNaN min must signal INVALID: {:?}",
+        e.flags(),
+    );
+}
+
+#[test]
+fn f32_max_snan_finite_signals_invalid() {
+    let mut e = env();
+    let snan = Float32::from_bits(SNAN);
+    let one = Float32::from_f32(1.0);
+    let r = snan.max(one, &mut e);
+    assert_eq!(r.to_bits(), one.to_bits());
+    assert!(
+        e.flags().contains(ExcFlags::INVALID),
+        "sNaN max must signal INVALID: {:?}",
+        e.flags(),
+    );
+}
+
+#[test]
+fn f32_min_both_qnan_returns_nan_without_invalid() {
+    let mut e = env();
+    let nan = Float32::from_bits(QNAN);
+    let r = nan.min(nan, &mut e);
+    assert!(r.is_nan());
+    assert!(
+        !e.flags().contains(ExcFlags::INVALID),
+        "two qNaNs to min must not raise INVALID: {:?}",
+        e.flags(),
+    );
+}
+
+#[test]
+fn f32_min_max_signed_ordering() {
+    let mut e = env();
+
+    // Mixed sign: negative is smaller than positive.
+    let a = Float32::from_f32(-3.0);
+    let b = Float32::from_f32(5.0);
+    assert_eq!(a.min(b, &mut e).to_bits(), a.to_bits());
+    assert_eq!(b.min(a, &mut e).to_bits(), a.to_bits());
+    assert_eq!(a.max(b, &mut e).to_bits(), b.to_bits());
+    assert_eq!(b.max(a, &mut e).to_bits(), b.to_bits());
+
+    // Both negative: more-negative magnitude is smaller.
+    let p = Float32::from_f32(-1.0);
+    let q = Float32::from_f32(-2.0);
+    assert_eq!(p.min(q, &mut e).to_bits(), q.to_bits());
+    assert_eq!(p.max(q, &mut e).to_bits(), p.to_bits());
+
+    // Both positive: smaller magnitude is smaller.
+    let r = Float32::from_f32(0.5);
+    let s = Float32::from_f32(1.0);
+    assert_eq!(r.min(s, &mut e).to_bits(), r.to_bits());
+    assert_eq!(r.max(s, &mut e).to_bits(), s.to_bits());
+}
+
+#[test]
+fn f32_min_max_with_infinities() {
+    let mut e = env();
+    let pinf = Float32::from_bits(POS_INF);
+    let ninf = Float32::from_bits(NEG_INF);
+    let v = Float32::from_f32(100.0);
+    assert_eq!(ninf.min(v, &mut e).to_bits(), NEG_INF);
+    assert_eq!(pinf.max(v, &mut e).to_bits(), POS_INF);
+    assert_eq!(ninf.min(pinf, &mut e).to_bits(), NEG_INF);
+    assert_eq!(ninf.max(pinf, &mut e).to_bits(), POS_INF);
+}
+
+// ── Float64 min/max smoke ──────────────────────────
+
+#[test]
+fn f64_min_pos_neg_zero_returns_neg_zero() {
+    use machina_softfloat::types::Float64;
+    let mut e = env();
+    let pz = Float64::from_f64(0.0);
+    let nz = Float64::from_bits(0x8000_0000_0000_0000);
+    assert_eq!(pz.min(nz, &mut e).to_bits(), 0x8000_0000_0000_0000);
+    assert_eq!(nz.min(pz, &mut e).to_bits(), 0x8000_0000_0000_0000);
+}
+
+#[test]
+fn f64_max_pos_neg_zero_returns_pos_zero() {
+    use machina_softfloat::types::Float64;
+    let mut e = env();
+    let pz = Float64::from_f64(0.0);
+    let nz = Float64::from_bits(0x8000_0000_0000_0000);
+    assert_eq!(pz.max(nz, &mut e).to_bits(), 0x0000_0000_0000_0000);
+    assert_eq!(nz.max(pz, &mut e).to_bits(), 0x0000_0000_0000_0000);
+}


### PR DESCRIPTION
## Summary

Closes #61. Adds IEEE 754 edge tests for `Float32::min`/`max` (plus
two `Float64` smokes) and fixes the implementation bug they
uncovered.

### Tests added in `tests/src/softfloat/edge_cases.rs`

- `min(+0, -0) = -0` and `max(+0, -0) = +0` (regardless of operand
  order),
- `min`/`max` with one **quiet** NaN returns the non-NaN operand and
  does not raise `INVALID`,
- `min`/`max` with one **signalling** NaN raises `INVALID` and
  returns the non-NaN operand,
- two qNaNs to `min` produce a NaN without `INVALID`,
- signed-ordering cases for mixed signs, both-negative,
  both-positive,
- min/max with infinities, including `±Inf` vs finite and `+Inf` vs
  `-Inf`,
- `Float64` smokes for the `+0`/`-0` corner.

### Implementation fix in `softfloat/src/ops/minmax.rs`

The infinity tests exposed a real bug: the same-sign branch of the
`min`/`max` comparison only inspects `pa.exp` / `pb.exp` from
`unpack`, which is **not** meaningful for `FloatClass::Inf`.
Concretely, `Float32::max(+Inf, 100.0)` returned `100.0` because the
sentinel exponent stored for `Inf` did not exceed the exponent for
`100.0`. After the existing NaN handling, short-circuit on
`FloatClass::Inf`: `-Inf` is always the smallest non-NaN value and
`+Inf` the largest, so the correct operand is picked from the sign
alone without consulting `exp`.

## Test plan

- [x] `cargo fmt --all --check`
- [x] `cargo clippy --workspace -- -D warnings -A clippy::pedantic -A clippy::nursery`
- [x] `cargo test -p machina-tests --lib softfloat::edge_cases::` (all 31 pass)