### PR TITLE
disas: emit .word for reserved RISC-V bitmanip encodings (#62)

### DIFF
--- a/disas/src/riscv.rs
+++ b/disas/src/riscv.rs
@@ -98,7 +98,7 @@ fn disasm32(insn: u32, pc: u64) -> String {
         0x03 => disasm_load(insn, funct3, rd, rs1),
         0x23 => disasm_store(insn, funct3, rs1, rs2),
         0x13 => disasm_op_imm(insn, funct3, rd, rs1),
-        0x33 => disasm_op(funct3, funct7, rd, rs1, rs2),
+        0x33 => disasm_op(insn, funct3, funct7, rd, rs1, rs2),
         0x1b => disasm_op_imm32(insn, funct3, rd, rs1),
         0x3b => disasm_op32(funct3, funct7, rd, rs1, rs2),
         0x2f => disasm_amo(insn, funct3, rd, rs1, rs2),
@@ -222,12 +222,16 @@ fn disasm_op_imm(insn: u32, f3: u32, rd: u32, rs1: u32) -> String {
                 };
                 return format!("{op} {}, {}", reg(rd), reg(rs1));
             }
-            // Zbs immediate shifts (funct6)
+            // RV64 funct3=1 OP-IMM is the I-type shift slot. Only the
+            // funct6 values below are assigned (slli plus Zbs/Zbb).
+            // Anything else is reserved per the RISC-V Unprivileged
+            // ISA (RV64I + Zbs).
             match funct6 {
+                0x00 => format!("slli {}, {}, {shamt}", reg(rd), reg(rs1)),
                 0x12 => format!("bclri {}, {}, {shamt}", reg(rd), reg(rs1)),
                 0x1a => format!("binvi {}, {}, {shamt}", reg(rd), reg(rs1)),
                 0x0a => format!("bseti {}, {}, {shamt}", reg(rd), reg(rs1)),
-                _ => format!("slli {}, {}, {shamt}", reg(rd), reg(rs1)),
+                _ => format!(".word {insn:#010x}"),
             }
         }
         2 => {
@@ -274,7 +278,14 @@ fn disasm_op_imm(insn: u32, f3: u32, rd: u32, rs1: u32) -> String {
     }
 }
 
-fn disasm_op(f3: u32, f7: u32, rd: u32, rs1: u32, rs2: u32) -> String {
+fn disasm_op(
+    insn: u32,
+    f3: u32,
+    f7: u32,
+    rd: u32,
+    rs1: u32,
+    rs2: u32,
+) -> String {
     // M extension
     if f7 == 1 {
         let op = match f3 {
@@ -324,8 +335,12 @@ fn disasm_op(f3: u32, f7: u32, rd: u32, rs1: u32, rs2: u32) -> String {
         (1, 0x05) => "clmul",
         (3, 0x05) => "clmulh",
         (2, 0x05) => "clmulr",
+        // Reserved or unassigned R-type encoding for OP. The
+        // Unprivileged ISA + bitmanip extensions only define the
+        // (f3, f7) pairs above; everything else must round-trip as
+        // raw machine code.
         _ => {
-            return format!("op f3={f3} f7={f7:#x}");
+            return format!(".word {insn:#010x}");
         }
     };
     // Pseudo: snez rd, rs2

--- a/tests/src/disas_bitmanip.rs
+++ b/tests/src/disas_bitmanip.rs
@@ -320,3 +320,76 @@ fn test_clmulr() {
     let insn = rtype(0x05, RS2, RS1, 2, RD, OP);
     assert_eq!(dis(insn), "clmulr a0, a1, a2");
 }
+
+// ===== Invalid / reserved bitmanip encodings (#62) =====
+//
+// For unknown or reserved encodings the riscv64 disassembler must
+// emit `.word 0x<insn>` rather than misclaim it as a recognised
+// instruction. Each test below picks an encoding adjacent to a
+// valid one and asserts the .word fallback, including the exact
+// preserved machine-code value.
+
+fn assert_dot_word(insn: u32) {
+    let txt = dis(insn);
+    let expected = format!(".word {insn:#010x}");
+    assert_eq!(
+        txt, expected,
+        "encoding {insn:#010x} must disassemble as `{expected}`",
+    );
+}
+
+// Zbb unary uses funct7=0x30, funct3=1 with shamt encoding the
+// operation: 0=clz, 1=ctz, 2=cpop, 4=sext.b, 5=sext.h. shamt=3 and
+// shamt>=6 are reserved.
+#[test]
+fn test_invalid_zbb_unary_shamt_3_is_word() {
+    assert_dot_word(ishift5(0x30, 3, RS1, 1, RD, OP_IMM));
+}
+
+#[test]
+fn test_invalid_zbb_unary_shamt_6_is_word() {
+    assert_dot_word(ishift5(0x30, 6, RS1, 1, RD, OP_IMM));
+}
+
+#[test]
+fn test_invalid_zbb_unary_shamt_7_is_word() {
+    assert_dot_word(ishift5(0x30, 7, RS1, 1, RD, OP_IMM));
+}
+
+// rev8 (RV64) is funct6=0x1a, shamt=0x38, funct3=5 in OP_IMM. Any
+// other shamt with funct6=0x1a is reserved.
+#[test]
+fn test_invalid_rev8_shamt_neighbours_are_word() {
+    // shamt=0x37 is one below the canonical rev8 encoding.
+    assert_dot_word(ishift6(0x1a, 0x37, RS1, 5, RD, OP_IMM));
+    // shamt=0x39 is one above.
+    assert_dot_word(ishift6(0x1a, 0x39, RS1, 5, RD, OP_IMM));
+}
+
+// orc.b is funct6=0x0a, shamt=0x07, funct3=5 in OP_IMM. Other shamt
+// values with funct6=0x0a are reserved.
+#[test]
+fn test_invalid_orc_b_shamt_neighbours_are_word() {
+    // shamt=0x06 is one below the canonical orc.b encoding.
+    assert_dot_word(ishift6(0x0a, 0x06, RS1, 5, RD, OP_IMM));
+    // shamt=0x08 is one above.
+    assert_dot_word(ishift6(0x0a, 0x08, RS1, 5, RD, OP_IMM));
+}
+
+// In the RV64 funct3=1 I-type shift slot (OP-IMM), only funct6 in
+// {0x00 slli, 0x12 bclri, 0x1a binvi, 0x0a bseti} is assigned; any
+// other funct6 must fall back to .word rather than masquerade as
+// slli (the previous catch-all behaviour).
+#[test]
+fn test_invalid_zbs_unassigned_funct6_is_word() {
+    // funct6=0x33 with funct3=1 is unassigned across RV64I + Zbs.
+    assert_dot_word(ishift6(0x33, 5, RS1, 1, RD, OP_IMM));
+}
+
+// Zbc lives in OP with funct7=0x05; the assigned funct3 values are
+// 1=clmul, 2=clmulr, 3=clmulh. funct3=0 with funct7=0x05 has no
+// assignment in RV64I+M+Zb*, so it must round-trip as .word.
+#[test]
+fn test_invalid_zbc_funct3_0_is_word() {
+    assert_dot_word(rtype(0x05, RS2, RS1, 0, RD, OP));
+}


### PR DESCRIPTION
Resolves gevico/machina#62.

## What

Pin down the `.word 0x<insn>` fallback for reserved or unassigned
bitmanip-adjacent encodings, and fix two disassembler branches that
misclassified them.

### Disassembler fixes (`disas/src/riscv.rs`)

- `disasm_op_imm` funct3=1 (RV64 I-type shift slot): the previous
  catch-all matched any unknown `funct6` as `slli`. Per the RISC-V
  Unprivileged ISA + Zbs, only `funct6 ∈ {0x00 slli, 0x12 bclri,
  0x1a binvi, 0x0a bseti}` is assigned in this slot. All other
  values are reserved and must disassemble to `.word`.
- `disasm_op` (R-type, opcode 0x33): the catch-all returned a
  non-spec placeholder `op f3=N f7=N`. The original `insn` is now
  threaded into the function and the catch-all returns `.word
  0x<insn>` so reserved Zbc/`Zb*` encodings round-trip cleanly.

### New regression tests (`tests/src/disas_bitmanip.rs`)

Each invalid encoding is asserted to disassemble *exactly* as
`.word 0x<insn>`, preserving the machine code. Coverage:

- Zbb unary (`funct7=0x30, funct3=1`) reserved `shamt` values
  (`shamt=3, 6, 7`).
- `rev8` (`funct6=0x1a, shamt=0x38, funct3=5`) shamt neighbours
  `0x37` and `0x39`.
- `orc.b` (`funct6=0x0a, shamt=0x07, funct3=5`) shamt neighbours
  `0x06` and `0x08`.
- An unassigned Zbs `funct6=0x33` with `funct3=1`.
- A reserved Zbc encoding `funct7=0x05, funct3=0`.

## Spec references

- RISC-V Unprivileged ISA, "I-type shift" (RV64I) — only
  `funct6=0` (`SLLI`/`SRLI`/`SRAI`) is assigned in the base.
- Zbs (`bclri/bseti/binvi/bexti`) defines `funct6 ∈ {0x12, 0x1a,
  0x0a, ...}` for the funct3=1 OP-IMM slot; other values are
  reserved.
- Zbb unary uses `funct7=0x30` with `rs2 ∈ {0,1,2,4,5}`.
- Zbc populates `funct7=0x05` only at `funct3 ∈ {1,2,3}`; the
  `funct3=0` slot is unassigned across RV64I+M+Zb*.

## Test plan

- [x] `cargo test -p machina-tests disas_bitmanip::` — 50 passed.
- [x] Existing valid bitmanip tests (slli, slli.uw, min, minu,
      max, maxu, clmul, clmulh, clmulr, …) still pass.
- [x] `make fmt-check` passes.
- [x] `make clippy` passes (zero warnings).