### PR TITLE
tests: add FlatView alias and disabled-region regressions (#69)

### DIFF
--- a/tests/src/memory_region.rs
+++ b/tests/src/memory_region.rs
@@ -128,3 +128,173 @@ fn test_address_space_read_write() {
     let val = a.read(GPA::new(0x200), 4) as u32;
     assert_eq!(&val.to_le_bytes(), msg);
 }
+
+// ===== FlatView alias / disabled-region regression tests (#69) =====
+//
+// These tests assert FlatView::ranges {addr, size, kind,
+// offset_in_region} for the four cases called out in the issue
+// checklist: RAM alias offset forwarding, container alias clipping,
+// disabled subregion suppression, and an alias overlapped by a
+// higher-priority MMIO mapping.
+
+fn ram_block_of(range: &FlatRange) -> Arc<RamBlock> {
+    match &range.kind {
+        FlatRangeKind::Ram { block } => Arc::clone(block),
+        _ => panic!("expected Ram range, got non-RAM kind"),
+    }
+}
+
+#[test]
+fn test_flat_view_ram_alias_forwards_offset_into_block() {
+    // 1 MiB RAM, aliased through a 0x2000-byte window starting at
+    // byte 0x4000 of the underlying block.
+    let (ram, ram_block) = MemoryRegion::ram("dram", 0x10_0000);
+    let alias = MemoryRegion::alias("alias", ram, 0x4000, 0x2000);
+
+    let mut root = MemoryRegion::container("root", u64::MAX);
+    root.add_subregion(alias, GPA::new(0x10_0000));
+
+    let fv = FlatView::from_region(&root);
+    assert_eq!(fv.ranges.len(), 1);
+    let r = &fv.ranges[0];
+    assert_eq!(r.addr, GPA::new(0x10_0000));
+    assert_eq!(r.size, 0x2000);
+    assert!(!r.is_io());
+    assert_eq!(
+        r.offset_in_region, 0x4000,
+        "alias offset must surface as offset_in_region for the leaf",
+    );
+    assert!(
+        Arc::ptr_eq(&ram_block, &ram_block_of(r)),
+        "alias must point at the original RAM block, not a copy",
+    );
+}
+
+#[test]
+fn test_flat_view_container_alias_clips_subregions() {
+    // Container with two RAM children:
+    //   sub_a: [0x0000..0x1000)
+    //   sub_b: [0x4000..0x5000)
+    // Alias window covers container bytes [0x800..0x4800), i.e. it
+    // spans the tail of sub_a (0x800..0x1000), the gap (0x1000..0x4000),
+    // and the head of sub_b (0x4000..0x4800). Only the parts that hit
+    // a live subregion should appear in the FlatView.
+    let (sub_a, _ba) = MemoryRegion::ram("sub_a", 0x1000);
+    let (sub_b, _bb) = MemoryRegion::ram("sub_b", 0x1000);
+    let mut container = MemoryRegion::container("c", 0x10_000);
+    container.add_subregion(sub_a, GPA::new(0x0000));
+    container.add_subregion(sub_b, GPA::new(0x4000));
+
+    let alias = MemoryRegion::alias("alias", container, 0x800, 0x4000);
+    let mut root = MemoryRegion::container("root", u64::MAX);
+    root.add_subregion(alias, GPA::new(0x20_0000));
+
+    let fv = FlatView::from_region(&root);
+    assert_eq!(
+        fv.ranges.len(),
+        2,
+        "alias clipping should produce exactly two clipped fragments",
+    );
+
+    // First fragment: [base..base+0x800), offset_in_region=0x800 (tail
+    // of sub_a starts at byte 0x800 of sub_a).
+    let r0 = &fv.ranges[0];
+    assert_eq!(r0.addr, GPA::new(0x20_0000));
+    assert_eq!(r0.size, 0x800);
+    assert_eq!(r0.offset_in_region, 0x800);
+
+    // Second fragment: head of sub_b, sized 0x800, mapped to
+    // [base + (sub_b.start - alias_off) .. base + 0x4000) =
+    // [base + 0x3800 .. base + 0x4000).
+    let r1 = &fv.ranges[1];
+    assert_eq!(r1.addr, GPA::new(0x20_0000 + 0x3800));
+    assert_eq!(r1.size, 0x800);
+    assert_eq!(
+        r1.offset_in_region, 0,
+        "head of sub_b is read from offset 0 of that subregion",
+    );
+}
+
+#[test]
+fn test_flat_view_disabled_subregion_is_omitted() {
+    let (ram_live, _live) = MemoryRegion::ram("live", 0x1000);
+    let (mut ram_dead, _dead) = MemoryRegion::ram("dead", 0x1000);
+    ram_dead.enabled = false;
+
+    let mut root = MemoryRegion::container("root", 0x10_000);
+    root.add_subregion(ram_live, GPA::new(0x0000));
+    root.add_subregion(ram_dead, GPA::new(0x1000));
+
+    let fv = FlatView::from_region(&root);
+    assert_eq!(fv.ranges.len(), 1);
+    assert_eq!(fv.ranges[0].addr, GPA::new(0x0000));
+
+    // Lookup inside the disabled window must miss.
+    assert!(
+        fv.lookup(GPA::new(0x1500)).is_none(),
+        "disabled region must not be reachable via lookup",
+    );
+    // And reads through AddressSpace return 0 rather than panicking.
+    let aspace = AddressSpace::new(root);
+    assert_eq!(aspace.read(GPA::new(0x1500), 1), 0);
+}
+
+#[test]
+fn test_flat_view_alias_to_disabled_target_yields_no_range() {
+    let (mut ram, _b) = MemoryRegion::ram("dram", 0x1000);
+    ram.enabled = false;
+    let alias = MemoryRegion::alias("alias", ram, 0, 0x1000);
+
+    let mut root = MemoryRegion::container("root", 0x10_000);
+    root.add_subregion(alias, GPA::new(0));
+
+    let fv = FlatView::from_region(&root);
+    assert!(
+        fv.ranges.is_empty(),
+        "alias whose target is disabled must contribute nothing",
+    );
+}
+
+#[test]
+fn test_flat_view_alias_overlapped_by_higher_priority_io_keeps_offsets() {
+    // Alias [base..base+0x1000) into RAM at byte 0x5000, priority 0.
+    // High-priority MMIO at [base+0x100..base+0x200), priority 10.
+    // Expected layout (sorted by address):
+    //   [0x0    .. 0x100)  RAM, offset_in_region = 0x5000
+    //   [0x100  .. 0x200)  IO,  priority 10
+    //   [0x200  .. 0x1000) RAM, offset_in_region = 0x5200
+    let (ram, _block) = MemoryRegion::ram("dram", 0x10_0000);
+    let alias = MemoryRegion::alias("alias", ram, 0x5000, 0x1000);
+    let io = MemoryRegion::io("uart", 0x100, Arc::new(MockUart::new()));
+
+    let mut root = MemoryRegion::container("root", u64::MAX);
+    root.add_subregion(alias, GPA::new(0));
+    root.add_subregion_with_priority(io, GPA::new(0x100), 10);
+
+    let fv = FlatView::from_region(&root);
+    assert_eq!(fv.ranges.len(), 3);
+
+    let r0 = &fv.ranges[0];
+    assert_eq!(r0.addr, GPA::new(0));
+    assert_eq!(r0.size, 0x100);
+    assert!(!r0.is_io());
+    assert_eq!(
+        r0.offset_in_region, 0x5000,
+        "left fragment must keep the alias base offset",
+    );
+
+    let r1 = &fv.ranges[1];
+    assert_eq!(r1.addr, GPA::new(0x100));
+    assert_eq!(r1.size, 0x100);
+    assert!(r1.is_io());
+
+    let r2 = &fv.ranges[2];
+    assert_eq!(r2.addr, GPA::new(0x200));
+    assert_eq!(r2.size, 0x1000 - 0x200);
+    assert!(!r2.is_io());
+    assert_eq!(
+        r2.offset_in_region,
+        0x5000 + 0x200,
+        "right fragment must shift offset_in_region by the gap",
+    );
+}


### PR DESCRIPTION
Resolves gevico/machina#69.

## What

Pin down the four FlatView cases called out in the issue checklist
so future changes to memory flattening cannot silently regress
alias-offset forwarding or disabled-region suppression. No changes
to \`memory/src/*\` — the current logic already behaves this way.

### New cases (\`tests/src/memory_region.rs\`)

| Test | What it asserts |
|------|------|
| \`test_flat_view_ram_alias_forwards_offset_into_block\` | alias_off appears as offset_in_region on the leaf range, and the leaf still references the original \`RamBlock\` (\`Arc::ptr_eq\`). |
| \`test_flat_view_container_alias_clips_subregions\` | An alias window straddling two children of a container produces clipped fragments at the right addresses with correct per-subregion offsets. |
| \`test_flat_view_disabled_subregion_is_omitted\` | \`enabled = false\` removes the range from FlatView, \`lookup\` misses, and \`AddressSpace::read\` returns 0 in the hole. |
| \`test_flat_view_alias_to_disabled_target_yields_no_range\` | An alias whose target is disabled contributes nothing. |
| \`test_flat_view_alias_overlapped_by_higher_priority_io_keeps_offsets\` | A higher-priority MMIO that punches through a RAM alias splits it into 3 ranges, with both surviving fragments keeping the right \`offset_in_region\` (alias_off and alias_off + gap). |

## Test plan

- [x] \`cargo test -p machina-tests memory_region::\` — 9 passed (4 existing + 5 new).
- [x] \`make fmt-check\` clean.
- [x] \`make clippy\` clean.