### PR TITLE
hw/core: document public clock/irq/mdev APIs (#80)

### DIFF
--- a/hw/core/src/clock.rs
+++ b/hw/core/src/clock.rs
@@ -15,6 +15,9 @@ pub struct DeviceClock {
 }
 
 impl DeviceClock {
+    /// Create a new enabled clock at `freq_hz`. The clock has no
+    /// children and a 1:1 multiplier/divider, so by default it
+    /// propagates the parent frequency unchanged.
     pub fn new(freq_hz: u64) -> Self {
         Self {
             freq_hz,

--- a/hw/core/src/irq.rs
+++ b/hw/core/src/irq.rs
@@ -4,6 +4,10 @@ use std::sync::{Arc, Mutex};
 
 /// Receives interrupt level changes.
 pub trait IrqSink: Send + Sync {
+    /// Drive the input line `irq` to `level` (true = high,
+    /// false = low). Implementations must be thread-safe and
+    /// must not block; level edges are conveyed as the post-
+    /// transition level, never as transient pulses.
     fn set_irq(&self, irq: u32, level: bool);
 }
 
@@ -15,18 +19,25 @@ pub struct IrqLine {
 }
 
 impl IrqLine {
+    /// Bind this wire to `sink` at downstream input number
+    /// `irq`. The line is conceptually low until `set`/`raise`
+    /// is called.
     pub fn new(sink: Arc<dyn IrqSink>, irq: u32) -> Self {
         Self { sink, irq }
     }
 
+    /// Drive the wire to `level`; forwarded verbatim to the
+    /// sink as `set_irq(self.irq, level)`.
     pub fn set(&self, level: bool) {
         self.sink.set_irq(self.irq, level);
     }
 
+    /// Drive the wire high. Equivalent to `self.set(true)`.
     pub fn raise(&self) {
         self.set(true);
     }
 
+    /// Drive the wire low. Equivalent to `self.set(false)`.
     pub fn lower(&self) {
         self.set(false);
     }
@@ -39,6 +50,9 @@ pub struct OrIrq {
 }
 
 impl OrIrq {
+    /// Build an OR gate with `num_inputs` independent input
+    /// lines, all initially low, that drives `output` high
+    /// whenever any input is high.
     pub fn new(output: IrqLine, num_inputs: usize) -> Self {
         Self {
             levels: Mutex::new(vec![false; num_inputs]),
@@ -62,6 +76,9 @@ pub struct SplitIrq {
 }
 
 impl SplitIrq {
+    /// Build a fan-out from a single input to all entries in
+    /// `outputs`. An empty `outputs` vector is permitted and
+    /// turns this into a no-op sink.
     pub fn new(outputs: Vec<IrqLine>) -> Self {
         Self { outputs }
     }
@@ -85,22 +102,32 @@ pub struct InterruptSource {
 }
 
 impl InterruptSource {
+    /// Bind a logical interrupt source to `sink` at input
+    /// number `irq_num`. The bound `irq_num` is fixed for the
+    /// lifetime of the source.
     pub fn new(sink: Arc<dyn IrqSink>, irq_num: u32) -> Self {
         Self { sink, irq_num }
     }
 
+    /// Drive the bound input high. Equivalent to
+    /// `self.set(true)` and safe to call from any thread.
     pub fn raise(&self) {
         self.sink.set_irq(self.irq_num, true);
     }
 
+    /// Drive the bound input low. Equivalent to
+    /// `self.set(false)` and safe to call from any thread.
     pub fn lower(&self) {
         self.sink.set_irq(self.irq_num, false);
     }
 
+    /// Drive the bound input to `level`. The level is forwarded
+    /// to the sink unchanged; no edge filtering is performed.
     pub fn set(&self, level: bool) {
         self.sink.set_irq(self.irq_num, level);
     }
 
+    /// The downstream input number this source was bound to.
     pub fn irq_num(&self) -> u32 {
         self.irq_num
     }

--- a/hw/core/src/mdev.rs
+++ b/hw/core/src/mdev.rs
@@ -64,6 +64,10 @@ pub struct MDeviceState {
 }
 
 impl MDeviceState {
+    /// Build a new device state in the `Created` lifecycle stage
+    /// with `local_id` as the underlying object id, no parent
+    /// bus, and an empty property set. Panics if `local_id` is
+    /// not a valid object id.
     pub fn new(local_id: &str) -> Self {
         Self {
             object: MObjectState::new_detached(local_id)
@@ -74,26 +78,37 @@ impl MDeviceState {
         }
     }
 
+    /// Borrow the underlying `MObjectState` (read-only).
     pub fn object(&self) -> &MObjectState {
         &self.object
     }
 
+    /// Mutably borrow the underlying `MObjectState`. Note that
+    /// the `MDeviceState` itself does not gate object-level
+    /// mutations on lifecycle.
     pub fn object_mut(&mut self) -> &mut MObjectState {
         &mut self.object
     }
 
+    /// The device's local id as registered on its parent bus.
     pub fn local_id(&self) -> &str {
         self.object.local_id()
     }
 
+    /// Current lifecycle stage (`Created` or `Realized`).
     pub fn lifecycle(&self) -> MDeviceLifecycle {
         self.lifecycle
     }
 
+    /// Convenience: `true` once `mark_realized` has succeeded
+    /// and `mark_unrealized` has not yet been called.
     pub fn is_realized(&self) -> bool {
         self.lifecycle == MDeviceLifecycle::Realized
     }
 
+    /// Record which parent bus this device is attached to.
+    /// Returns `LateMutation("parent_bus")` if the device is
+    /// already realized.
     pub fn set_parent_bus(&mut self, bus: &str) -> Result<(), MDeviceError> {
         if self.is_realized() {
             return Err(MDeviceError::LateMutation("parent_bus"));
@@ -102,10 +117,15 @@ impl MDeviceState {
         Ok(())
     }
 
+    /// The parent bus name, if `set_parent_bus` has been called.
     pub fn parent_bus(&self) -> Option<&str> {
         self.parent_bus.as_deref()
     }
 
+    /// Register a new property schema entry. Returns
+    /// `LateMutation("property_schema")` if the device is
+    /// already realized, or `DuplicateProperty(name)` if a
+    /// property with the same name was already defined.
     pub fn define_property(
         &mut self,
         spec: MPropertySpec,
@@ -116,6 +136,9 @@ impl MDeviceState {
         self.properties.define(spec)
     }
 
+    /// Assign `value` to the property `name`. Whether the
+    /// assignment is allowed at the current lifecycle stage is
+    /// decided by the property set.
     pub fn set_property(
         &mut self,
         name: &str,
@@ -124,22 +147,33 @@ impl MDeviceState {
         self.properties.set(self.lifecycle, name, value)
     }
 
+    /// Read the current value of property `name`, or `None` if
+    /// the property is not set (and not defined with a default).
     pub fn property(&self, name: &str) -> Option<&MPropertyValue> {
         self.properties.get(name)
     }
 
+    /// Look up the schema entry registered for property `name`.
     pub fn property_spec(&self, name: &str) -> Option<&MPropertySpec> {
         self.properties.spec(name)
     }
 
+    /// All property names currently registered, in insertion
+    /// order.
     pub fn property_names(&self) -> Vec<&str> {
         self.properties.names()
     }
 
+    /// Verify that every required property has a value. Returns
+    /// `MissingRequiredProperty(name)` for the first missing
+    /// required property encountered.
     pub fn validate_properties(&self) -> Result<(), MDeviceError> {
         self.properties.validate_required()
     }
 
+    /// Move the device from `Created` to `Realized`. Validates
+    /// required properties first; returns `AlreadyRealized` if
+    /// the device is already realized.
     pub fn mark_realized(&mut self) -> Result<(), MDeviceError> {
         if self.is_realized() {
             return Err(MDeviceError::AlreadyRealized);
@@ -149,6 +183,8 @@ impl MDeviceState {
         Ok(())
     }
 
+    /// Move the device back from `Realized` to `Created`.
+    /// Returns `NotRealized` if the device was not realized.
     pub fn mark_unrealized(&mut self) -> Result<(), MDeviceError> {
         if !self.is_realized() {
             return Err(MDeviceError::NotRealized);


### PR DESCRIPTION
Resolves gevico/machina#80 (clock/irq/mdev portion).

## What

Add \`///\` doc comments to the public methods on the three modules
the issue title calls out — \`clock.rs\`, \`irq.rs\`, \`mdev.rs\` —
so contributors learning the hardware abstraction layer get the
same context that the existing tests have implicitly relied on.

\`bus.rs\` and \`property.rs\` are also mentioned in the issue body
and would be a reasonable follow-up; keeping this PR scoped to the
title-named modules to ease review.

### Coverage

- \`clock.rs\`: explain \`DeviceClock::new\` defaults (enabled, 1:1
  multiplier/divider, no children).
- \`irq.rs\`:
  - \`IrqSink::set_irq\` semantics — level not pulse, thread-safe,
    non-blocking.
  - \`IrqLine::{new, set, raise, lower}\`.
  - \`OrIrq::new\` (initial-low inputs and OR semantics).
  - \`SplitIrq::new\` (empty output vector permitted).
  - \`InterruptSource::{new, raise, lower, set, irq_num}\`.
- \`mdev.rs\`: all twelve public methods on \`MDeviceState\`,
  including which ones reject mutation after realize and which
  error variant is returned (\`LateMutation\`,
  \`AlreadyRealized\`, \`NotRealized\`,
  \`MissingRequiredProperty\`).

## Test plan

- [x] \`cargo check -p machina-hw-core\` clean.
- [x] \`make fmt-check\` clean.
- [x] \`make clippy\` clean.
- [x] \`cargo test -p machina-tests hw_clock\`, \`hw_irq\`, \`hw_qdev\`
      all pass — confirming the doc comments do not perturb
      anything.