### PR TITLE
hw/core: validate ELF segments before writing guest memory (#57)

### DIFF
--- a/hw/core/src/loader.rs
+++ b/hw/core/src/loader.rs
@@ -4,6 +4,7 @@ use machina_core::address::GPA;
 use machina_memory::AddressSpace;
 
 /// Information returned after a successful load.
+#[derive(Debug)]
 pub struct LoadInfo {
     /// Entry point address.
     pub entry: GPA,
@@ -112,6 +113,17 @@ fn parse_elf_header(data: &[u8]) -> Result<ElfHeader, String> {
     })
 }
 
+/// Pre-validated PT_LOAD descriptor produced by the first pass
+/// of `load_elf`. Once one of these exists every offset is known
+/// to be in bounds and every address sum is known not to wrap, so
+/// the second pass can write without re-checking.
+struct PtLoadSeg {
+    load_addr: u64,
+    p_offset: usize,
+    p_filesz: usize,
+    p_memsz: u64,
+}
+
 /// Load an ELF-64 binary into the address space and return
 /// the entry point.
 ///
@@ -119,6 +131,12 @@ fn parse_elf_header(data: &[u8]) -> Result<ElfHeader, String> {
 /// For ET_DYN (PIE) segments are loaded relative to
 /// `base_addr`.  The `LoadInfo.bias` field carries the
 /// offset so the caller can relocate the entry address.
+///
+/// All PT_LOAD segments are validated in a first pass — header
+/// bounds, file-data bounds, `p_filesz <= p_memsz`, and address
+/// arithmetic are all checked — before any byte is written, so a
+/// malformed ELF cannot leave guest memory in a partially loaded
+/// state.
 pub fn load_elf(
     data: &[u8],
     base_addr: u64,
@@ -128,14 +146,25 @@ pub fn load_elf(
 
     let is_dyn = hdr.e_type == ET_DYN;
 
-    let mut total_loaded: u64 = 0;
+    let mut segs: Vec<PtLoadSeg> = Vec::new();
+    let mut total_memsz: u64 = 0;
     let mut low_addr: u64 = u64::MAX;
     let mut high_addr: u64 = 0;
 
+    // Pass 1: parse and validate every PT_LOAD segment.
     for i in 0..hdr.e_phnum {
-        let off = hdr.e_phoff + i * hdr.e_phentsize;
-        if off + ELF64_PHDR_SIZE > data.len() {
-            return Err("phdr out of bounds".into());
+        let stride = i
+            .checked_mul(hdr.e_phentsize)
+            .ok_or_else(|| format!("phdr {i} offset arithmetic overflow"))?;
+        let off = hdr
+            .e_phoff
+            .checked_add(stride)
+            .ok_or_else(|| format!("phdr {i} offset arithmetic overflow"))?;
+        let off_end = off
+            .checked_add(ELF64_PHDR_SIZE)
+            .ok_or_else(|| format!("phdr {i} extends past usize"))?;
+        if off_end > data.len() {
+            return Err(format!("phdr {i} out of bounds"));
         }
 
         let p_type = u32::from_le_bytes(data[off..off + 4].try_into().unwrap());
@@ -143,39 +172,74 @@ pub fn load_elf(
             continue;
         }
 
-        let p_offset =
-            u64::from_le_bytes(data[off + 8..off + 16].try_into().unwrap())
-                as usize;
+        let p_offset_u64 =
+            u64::from_le_bytes(data[off + 8..off + 16].try_into().unwrap());
         let p_vaddr =
             u64::from_le_bytes(data[off + 16..off + 24].try_into().unwrap());
         let p_paddr =
             u64::from_le_bytes(data[off + 24..off + 32].try_into().unwrap());
-        let p_filesz =
-            u64::from_le_bytes(data[off + 32..off + 40].try_into().unwrap())
-                as usize;
+        let p_filesz_u64 =
+            u64::from_le_bytes(data[off + 32..off + 40].try_into().unwrap());
         let p_memsz =
             u64::from_le_bytes(data[off + 40..off + 48].try_into().unwrap());
 
-        // For ET_DYN: load address = base_addr + p_vaddr.
-        // For ET_EXEC: load address = p_paddr (absolute).
-        let load_addr = if is_dyn { base_addr + p_vaddr } else { p_paddr };
+        if p_filesz_u64 > p_memsz {
+            return Err(format!("PT_LOAD segment {i}: p_filesz > p_memsz"));
+        }
 
-        if p_offset + p_filesz > data.len() {
+        let p_offset = usize::try_from(p_offset_u64).map_err(|_| {
+            format!("PT_LOAD segment {i}: p_offset exceeds usize")
+        })?;
+        let p_filesz = usize::try_from(p_filesz_u64).map_err(|_| {
+            format!("PT_LOAD segment {i}: p_filesz exceeds usize")
+        })?;
+        let file_end = p_offset.checked_add(p_filesz).ok_or_else(|| {
+            format!("PT_LOAD segment {i}: file range arithmetic overflow")
+        })?;
+        if file_end > data.len() {
             return Err(format!(
-                "PT_LOAD segment {i} file data \
-                 out of bounds"
+                "PT_LOAD segment {i}: segment file data out of bounds"
             ));
         }
 
-        let seg = &data[p_offset..p_offset + p_filesz];
-        write_bytes(as_, GPA::new(load_addr), seg);
+        let load_addr = if is_dyn {
+            base_addr.checked_add(p_vaddr).ok_or_else(|| {
+                format!("PT_LOAD segment {i}: base_addr + p_vaddr overflow")
+            })?
+        } else {
+            p_paddr
+        };
+        let seg_end = load_addr.checked_add(p_memsz).ok_or_else(|| {
+            format!("PT_LOAD segment {i}: load_addr + p_memsz overflow")
+        })?;
+
         if load_addr < low_addr {
             low_addr = load_addr;
         }
+        if seg_end > high_addr {
+            high_addr = seg_end;
+        }
+        total_memsz = total_memsz.checked_add(p_memsz).ok_or_else(|| {
+            format!("PT_LOAD segment {i}: total memsz overflow")
+        })?;
+
+        segs.push(PtLoadSeg {
+            load_addr,
+            p_offset,
+            p_filesz,
+            p_memsz,
+        });
+    }
+
+    // Pass 2: write all validated segments. Arithmetic here cannot
+    // overflow because pass 1 already vetted every address.
+    for s in &segs {
+        let seg = &data[s.p_offset..s.p_offset + s.p_filesz];
+        write_bytes(as_, GPA::new(s.load_addr), seg);
 
         // BSS: zero-fill [p_filesz .. p_memsz)
-        let bss_start = load_addr + p_filesz as u64;
-        let bss_end = load_addr + p_memsz;
+        let bss_start = s.load_addr + s.p_filesz as u64;
+        let bss_end = s.load_addr + s.p_memsz;
         let mut cur = bss_start;
         while cur < bss_end {
             let remain = bss_end - cur;
@@ -187,17 +251,13 @@ pub fn load_elf(
                 cur += 1;
             }
         }
-
-        total_loaded += p_memsz;
-        let seg_end = load_addr + p_memsz;
-        if seg_end > high_addr {
-            high_addr = seg_end;
-        }
     }
 
     // For ET_DYN the actual entry = base_addr + e_entry.
     let entry = if is_dyn {
-        base_addr + hdr.e_entry
+        base_addr
+            .checked_add(hdr.e_entry)
+            .ok_or_else(|| "entry address overflow".to_string())?
     } else {
         hdr.e_entry
     };
@@ -206,7 +266,7 @@ pub fn load_elf(
 
     Ok(LoadInfo {
         entry: GPA::new(entry),
-        size: total_loaded,
+        size: total_memsz,
         low_addr: if low_addr == u64::MAX { 0 } else { low_addr },
         high_addr,
         bias,
@@ -337,8 +397,10 @@ pub fn elf_phys_entry(data: &[u8], virt_entry: u64) -> Option<u64> {
         return None;
     }
     for i in 0..hdr.e_phnum {
-        let off = hdr.e_phoff + i * hdr.e_phentsize;
-        if off + ELF64_PHDR_SIZE > data.len() {
+        let stride = i.checked_mul(hdr.e_phentsize)?;
+        let off = hdr.e_phoff.checked_add(stride)?;
+        let off_end = off.checked_add(ELF64_PHDR_SIZE)?;
+        if off_end > data.len() {
             return None;
         }
         let p_type = u32::from_le_bytes(data[off..off + 4].try_into().unwrap());

--- a/tests/src/hw_loader.rs
+++ b/tests/src/hw_loader.rs
@@ -237,3 +237,177 @@ fn test_load_elf_dyn_pie() {
         assert_eq!(actual, exp, "mismatch at offset {i}");
     }
 }
+
+// ===== Malformed-ELF boundary checks (#57) =====
+//
+// These tests cover four classes of malformed input that the
+// loader must reject without panicking and without leaving guest
+// memory partially written: p_filesz > p_memsz, out-of-bounds
+// program headers, out-of-bounds segment file data, and arithmetic
+// overflow in the offset computation.
+
+/// Build an ELF-64 ET_EXEC blob with one PT_LOAD segment whose
+/// raw header fields can be patched per-test.
+fn build_one_segment_elf(
+    p_offset: u64,
+    p_paddr: u64,
+    p_filesz: u64,
+    p_memsz: u64,
+    payload: &[u8],
+) -> Vec<u8> {
+    let mut elf = vec![0u8; 64 + 56];
+    elf[0..4].copy_from_slice(&[0x7f, b'E', b'L', b'F']);
+    elf[4] = 2; // ELFCLASS64
+    elf[5] = 1; // ELFDATA2LSB
+    elf[6] = 1; // EV_CURRENT
+    elf[16..18].copy_from_slice(&2u16.to_le_bytes()); // ET_EXEC
+    elf[20..24].copy_from_slice(&1u32.to_le_bytes());
+    elf[24..32].copy_from_slice(&p_paddr.to_le_bytes()); // e_entry
+    elf[32..40].copy_from_slice(&64u64.to_le_bytes()); // e_phoff
+    elf[52..54].copy_from_slice(&64u16.to_le_bytes()); // e_ehsize
+    elf[54..56].copy_from_slice(&56u16.to_le_bytes()); // e_phentsize
+    elf[56..58].copy_from_slice(&1u16.to_le_bytes()); // e_phnum
+
+    let ph = 64usize;
+    elf[ph..ph + 4].copy_from_slice(&1u32.to_le_bytes()); // PT_LOAD
+    elf[ph + 8..ph + 16].copy_from_slice(&p_offset.to_le_bytes());
+    elf[ph + 16..ph + 24].copy_from_slice(&p_paddr.to_le_bytes());
+    elf[ph + 24..ph + 32].copy_from_slice(&p_paddr.to_le_bytes());
+    elf[ph + 32..ph + 40].copy_from_slice(&p_filesz.to_le_bytes());
+    elf[ph + 40..ph + 48].copy_from_slice(&p_memsz.to_le_bytes());
+    elf.extend_from_slice(payload);
+    elf
+}
+
+#[test]
+fn test_load_elf_rejects_p_filesz_greater_than_p_memsz() {
+    let as_ = make_ram_as(0x10000);
+    // p_filesz = 8, p_memsz = 4 -> illegal per ELF spec.
+    let payload: [u8; 8] = [0xAA; 8];
+    let elf = build_one_segment_elf(120, 0x2000, 8, 4, &payload);
+
+    let err = load_elf(&elf, 0, &as_).expect_err("must reject filesz > memsz");
+    assert!(
+        err.contains("p_filesz") && err.contains("p_memsz"),
+        "error message should name p_filesz/p_memsz, got: {err}",
+    );
+}
+
+#[test]
+fn test_load_elf_rejects_phdr_out_of_bounds() {
+    let as_ = make_ram_as(0x10000);
+    // Build a normal ELF, then bump e_phoff past the end of the
+    // file so the program header read would walk off the buffer.
+    let payload: [u8; 4] = [0x55; 4];
+    let mut elf = build_one_segment_elf(120, 0x2000, 4, 4, &payload);
+    let bogus_phoff: u64 = elf.len() as u64 + 1024;
+    elf[32..40].copy_from_slice(&bogus_phoff.to_le_bytes());
+
+    let err = load_elf(&elf, 0, &as_).expect_err("must reject phdr OOB");
+    assert!(
+        err.contains("phdr"),
+        "error message should mention phdr, got: {err}",
+    );
+}
+
+#[test]
+fn test_load_elf_rejects_segment_file_data_out_of_bounds() {
+    let as_ = make_ram_as(0x10000);
+    // Claim p_filesz=4096 but only attach 8 bytes of payload.
+    let payload: [u8; 8] = [0x12; 8];
+    let elf = build_one_segment_elf(120, 0x2000, 4096, 4096, &payload);
+
+    let err = load_elf(&elf, 0, &as_).expect_err("must reject segment OOB");
+    assert!(
+        err.contains("file data out of bounds"),
+        "error should describe segment-file-data bounds, got: {err}",
+    );
+}
+
+#[test]
+fn test_load_elf_rejects_p_offset_arithmetic_overflow() {
+    let as_ = make_ram_as(0x10000);
+    // p_offset = u64::MAX, p_filesz = 1 -> p_offset+p_filesz wraps.
+    let payload: [u8; 0] = [];
+    let elf = build_one_segment_elf(u64::MAX, 0x2000, 1, 1, &payload);
+
+    let err =
+        load_elf(&elf, 0, &as_).expect_err("must reject overflowing offset");
+    // Either the usize conversion fails or the checked_add fails.
+    assert!(
+        err.contains("p_offset")
+            || err.contains("file range arithmetic overflow")
+            || err.contains("out of bounds"),
+        "error should describe an arithmetic / bounds problem, got: {err}",
+    );
+}
+
+#[test]
+fn test_load_elf_rejection_does_not_partially_write_memory() {
+    let as_ = make_ram_as(0x10000);
+    // Construct a two-segment ELF where segment 0 is valid but
+    // segment 1 has p_filesz > p_memsz. The first valid segment
+    // must NOT be written before the loader rejects the input.
+    let entry: u64 = 0x1000;
+    let payload0: [u8; 4] = [0xAB, 0xCD, 0xEF, 0x12];
+    let p_paddr0: u64 = 0x1000;
+    let p_paddr1: u64 = 0x2000;
+
+    // Layout:
+    //   [0 ..  64) ehdr
+    //   [64.. 120) phdr0
+    //   [120..176) phdr1
+    //   [176..180) payload0
+    let mut elf = vec![0u8; 64 + 56 * 2];
+    elf[0..4].copy_from_slice(&[0x7f, b'E', b'L', b'F']);
+    elf[4] = 2;
+    elf[5] = 1;
+    elf[6] = 1;
+    elf[16..18].copy_from_slice(&2u16.to_le_bytes()); // ET_EXEC
+    elf[20..24].copy_from_slice(&1u32.to_le_bytes());
+    elf[24..32].copy_from_slice(&entry.to_le_bytes());
+    elf[32..40].copy_from_slice(&64u64.to_le_bytes());
+    elf[52..54].copy_from_slice(&64u16.to_le_bytes());
+    elf[54..56].copy_from_slice(&56u16.to_le_bytes());
+    elf[56..58].copy_from_slice(&2u16.to_le_bytes()); // e_phnum = 2
+
+    // phdr0: valid, p_filesz=4, p_memsz=4.
+    let ph0 = 64usize;
+    let p_offset0: u64 = 64 + 56 * 2;
+    elf[ph0..ph0 + 4].copy_from_slice(&1u32.to_le_bytes());
+    elf[ph0 + 8..ph0 + 16].copy_from_slice(&p_offset0.to_le_bytes());
+    elf[ph0 + 16..ph0 + 24].copy_from_slice(&p_paddr0.to_le_bytes());
+    elf[ph0 + 24..ph0 + 32].copy_from_slice(&p_paddr0.to_le_bytes());
+    elf[ph0 + 32..ph0 + 40].copy_from_slice(&4u64.to_le_bytes());
+    elf[ph0 + 40..ph0 + 48].copy_from_slice(&4u64.to_le_bytes());
+
+    // phdr1: malformed, p_filesz=8 > p_memsz=4.
+    let ph1 = 64 + 56;
+    elf[ph1..ph1 + 4].copy_from_slice(&1u32.to_le_bytes());
+    elf[ph1 + 8..ph1 + 16].copy_from_slice(&p_offset0.to_le_bytes());
+    elf[ph1 + 16..ph1 + 24].copy_from_slice(&p_paddr1.to_le_bytes());
+    elf[ph1 + 24..ph1 + 32].copy_from_slice(&p_paddr1.to_le_bytes());
+    elf[ph1 + 32..ph1 + 40].copy_from_slice(&8u64.to_le_bytes());
+    elf[ph1 + 40..ph1 + 48].copy_from_slice(&4u64.to_le_bytes());
+
+    elf.extend_from_slice(&payload0);
+
+    // Pre-fill the target with a sentinel so we can detect any
+    // accidental write from segment 0.
+    for i in 0..4 {
+        as_.write(GPA::new(p_paddr0 + i), 1, 0xA5);
+    }
+
+    let err = load_elf(&elf, 0, &as_)
+        .expect_err("two-pass validation must reject this ELF");
+    assert!(err.contains("p_filesz"));
+
+    for i in 0..4u64 {
+        let got = as_.read(GPA::new(p_paddr0 + i), 1) as u8;
+        assert_eq!(
+            got, 0xA5,
+            "segment 0 byte {i} should still be the sentinel; load_elf \
+             must validate every segment before writing any of them",
+        );
+    }
+}


### PR DESCRIPTION
Resolves gevico/machina#57.

## What

Tighten the ELF loader's bounds checking so that:
- malformed ELFs cannot panic on integer-overflow arithmetic
- malformed ELFs cannot leave guest memory partially loaded
- the mandatory invariant \`p_filesz <= p_memsz\` is enforced

### Key change: two-pass load

\`load_elf\` now collects validated \`PtLoadSeg\` descriptors in a
first pass, then performs all writes only after every segment
passes validation. A broken segment 1 will no longer have already
written segment 0 to guest RAM.

### Checked arithmetic

Replace bare \`+\` / \`*\` with \`checked_add\` / \`checked_mul\`
for:
- \`e_phoff + i * e_phentsize\` (and the trailing \`+ ELF64_PHDR_SIZE\`)
- \`p_offset + p_filesz\`
- \`base_addr + p_vaddr\` (ET_DYN)
- \`load_addr + p_memsz\`
- \`base_addr + e_entry\` (ET_DYN entry)
- accumulating \`total_memsz\`

Same treatment is applied to \`elf_phys_entry\` for parity.

### New mandatory check

\`p_filesz > p_memsz\` is now rejected with a descriptive error
message — previously it would silently succeed and the loader
would later read \`p_filesz\` bytes that are not supposed to fit
in the segment's memory image.

### Misc

\`LoadInfo\` now derives \`Debug\` so callers (and tests) can use
the standard \`Result\` helpers like \`expect_err\`.

## New tests (\`tests/src/hw_loader.rs\`)

| Test | What it pins down |
|------|-------------------|
| \`test_load_elf_rejects_p_filesz_greater_than_p_memsz\` | Spec invariant rejected with named error. |
| \`test_load_elf_rejects_phdr_out_of_bounds\` | \`e_phoff\` past EOF is rejected. |
| \`test_load_elf_rejects_segment_file_data_out_of_bounds\` | \`p_offset + p_filesz > data.len()\` rejected. |
| \`test_load_elf_rejects_p_offset_arithmetic_overflow\` | \`p_offset = u64::MAX\` trips the checked path, no panic. |
| \`test_load_elf_rejection_does_not_partially_write_memory\` | Two-segment ELF where seg 0 is valid and seg 1 is malformed: load returns Err AND seg 0 bytes are not written (verified with a sentinel pre-fill). |

## Test plan

- [x] \`cargo test -p machina-tests hw_loader\` — 12 passed (7 existing + 5 new).
- [x] \`make fmt-check\` clean.
- [x] \`make clippy\` clean.