### PR TITLE
core: tighten -netdev/-device validation up front (#59)

### DIFF
--- a/core/src/machine.rs
+++ b/core/src/machine.rs
@@ -17,6 +17,12 @@ pub struct NetdevOpts {
 impl NetdevOpts {
     /// Parse `-netdev` and optional `-device
     /// virtio-net-device` into NetdevOpts.
+    ///
+    /// Empty value strings (`id=`, `ifname=`, `netdev=`) are
+    /// rejected up front so callers don't fail later inside
+    /// device init or TAP setup. Only `tap` netdevs and
+    /// `virtio-net-device` device strings are accepted; anything
+    /// else returns an explicit `Err` naming the field at fault.
     pub fn parse(
         netdev_raw: &str,
         device_raw: Option<&str>,
@@ -32,8 +38,14 @@ impl NetdevOpts {
         let mut ifname = None;
         for part in netdev_raw.split(',').skip(1) {
             if let Some(v) = part.strip_prefix("id=") {
+                if v.is_empty() {
+                    return Err("-netdev: empty id= value".to_string());
+                }
                 id = Some(v.to_string());
             } else if let Some(v) = part.strip_prefix("ifname=") {
+                if v.is_empty() {
+                    return Err("-netdev: empty ifname= value".to_string());
+                }
                 ifname = Some(v.to_string());
             }
         }
@@ -43,11 +55,32 @@ impl NetdevOpts {
 
         let mut mac = None;
         if let Some(dev) = device_raw {
+            // First sub-token is the device kind. Only
+            // virtio-net-device is supported here; anything else
+            // is rejected explicitly so the user gets a clear
+            // error rather than silently dropping the field.
+            let kind = dev.split(',').next().unwrap_or("");
+            if kind != "virtio-net-device" {
+                return Err(format!(
+                    "-device: unsupported type \
+                     (expected virtio-net-device): {kind}",
+                ));
+            }
             let mut dev_netdev = None;
             for part in dev.split(',').skip(1) {
                 if let Some(v) = part.strip_prefix("netdev=") {
+                    if v.is_empty() {
+                        return Err("-device virtio-net-device: \
+                             empty netdev= value"
+                            .to_string());
+                    }
                     dev_netdev = Some(v.to_string());
                 } else if let Some(v) = part.strip_prefix("mac=") {
+                    if v.is_empty() {
+                        return Err("-device virtio-net-device: \
+                             empty mac= value"
+                            .to_string());
+                    }
                     mac = Some(v.to_string());
                 }
             }

--- a/tests/src/cli_netdev.rs
+++ b/tests/src/cli_netdev.rs
@@ -65,3 +65,73 @@ fn test_parse_device_netdev_id_mismatch() {
     assert!(result.is_err());
     assert!(result.unwrap_err().contains("does not match"));
 }
+
+// ===== Empty-value and unsupported-device validation (#59) =====
+
+#[test]
+fn test_parse_netdev_empty_id_is_rejected() {
+    let result = NetdevOpts::parse("tap,id=,ifname=tap0", None);
+    let err = result.unwrap_err();
+    assert!(
+        err.contains("empty id"),
+        "error message must name the empty id field, got: {err}",
+    );
+}
+
+#[test]
+fn test_parse_netdev_empty_ifname_is_rejected() {
+    let result = NetdevOpts::parse("tap,id=net0,ifname=", None);
+    let err = result.unwrap_err();
+    assert!(
+        err.contains("empty ifname"),
+        "error message must name the empty ifname field, got: {err}",
+    );
+}
+
+#[test]
+fn test_parse_device_empty_netdev_is_rejected() {
+    let result = NetdevOpts::parse(
+        "tap,id=net0,ifname=tap0",
+        Some("virtio-net-device,netdev="),
+    );
+    let err = result.unwrap_err();
+    assert!(
+        err.contains("empty netdev"),
+        "error must name the empty netdev= value, got: {err}",
+    );
+}
+
+#[test]
+fn test_parse_device_empty_mac_is_rejected() {
+    let result = NetdevOpts::parse(
+        "tap,id=net0,ifname=tap0",
+        Some("virtio-net-device,netdev=net0,mac="),
+    );
+    let err = result.unwrap_err();
+    assert!(
+        err.contains("empty mac"),
+        "error must name the empty mac= value, got: {err}",
+    );
+}
+
+#[test]
+fn test_parse_device_unknown_kind_is_rejected() {
+    // Unsupported -device kinds must be flagged here, not
+    // silently accepted with their fields ignored.
+    let result =
+        NetdevOpts::parse("tap,id=net0,ifname=tap0", Some("e1000,netdev=net0"));
+    let err = result.unwrap_err();
+    assert!(
+        err.contains("unsupported type") && err.contains("e1000"),
+        "error must name the unsupported device kind, got: {err}",
+    );
+}
+
+#[test]
+fn test_parse_netdev_extra_commas_do_not_panic() {
+    // Trailing/repeated separators are tolerated but the
+    // required fields still need to be present.
+    let nd = NetdevOpts::parse("tap,,id=net0,,ifname=tap0,", None).unwrap();
+    assert_eq!(nd.id, "net0");
+    assert_eq!(nd.ifname, "tap0");
+}


### PR DESCRIPTION
Resolves gevico/machina#59.

## What

\`NetdevOpts::parse\` already rejected missing required fields,
non-tap netdev types, missing \`netdev=\`, and id mismatches. Two
classes of malformed input still slipped through to later
device-init or TAP-setup failures:

- **Empty value strings** — \`id=\`, \`ifname=\`, \`netdev=\`, \`mac=\`
  were accepted as empty strings.
- **Wrong device kind** — anything that wasn't
  \`virtio-net-device\` was silently treated as one as long as it
  had a \`netdev=\` field.

Both are now rejected at parse time with explicit, field-named
error strings (\`empty id= value\`, \`empty ifname= value\`,
\`empty netdev= value\`, \`empty mac= value\`,
\`unsupported type (expected virtio-net-device): <kind>\`).

## New tests

\`tests/src/cli_netdev.rs\`:

- \`test_parse_netdev_empty_id_is_rejected\`
- \`test_parse_netdev_empty_ifname_is_rejected\`
- \`test_parse_device_empty_netdev_is_rejected\`
- \`test_parse_device_empty_mac_is_rejected\`
- \`test_parse_device_unknown_kind_is_rejected\`
- \`test_parse_netdev_extra_commas_do_not_panic\` (tolerant input)

Per the issue's "tests should not depend on host network
privileges" requirement, all tests run \`NetdevOpts::parse\`
directly and never open a TAP.

## Test plan

- [x] \`cargo test -p machina-tests cli_netdev\` — 13 passed (7 existing + 6 new).
- [x] \`make fmt-check\` clean.
- [x] \`make clippy\` clean.