### PR TITLE
decode: surface line numbers and validate argset references (#73)

### DIFF
--- a/decode/src/lib.rs
+++ b/decode/src/lib.rs
@@ -50,6 +50,7 @@ pub struct Pattern {
     pub field_map: BTreeMap<String, FieldMapping>,
 }
 
+#[derive(Debug)]
 pub struct Parsed {
     pub fields: BTreeMap<String, Field>,
     pub argsets: BTreeMap<String, ArgSet>,
@@ -79,6 +80,7 @@ pub fn is_inline_field(s: &str) -> bool {
     }
 }
 
+#[derive(Debug)]
 pub struct BitPatternResult {
     pub fixedbits: u32,
     pub fixedmask: u32,
@@ -386,38 +388,57 @@ pub fn parse_with_width(input: &str, width: u32) -> Result<Parsed, String> {
             continue;
         }
         let first = line.chars().next().unwrap();
-        let result: Result<(), String> = match first {
-            '%' => {
-                let f = parse_field(line)?;
-                fields.insert(f.name.clone(), f);
-                Ok(())
+        // Wrap the dispatch in a closure so the inner `?`s
+        // propagate to `result` (and pick up the line-number
+        // prefix) instead of the enclosing function.
+        let result: Result<(), String> = (|| -> Result<(), String> {
+            match first {
+                '%' => {
+                    let f = parse_field(line)?;
+                    fields.insert(f.name.clone(), f);
+                    Ok(())
+                }
+                '&' => {
+                    let a = parse_argset(line)?;
+                    argsets.insert(a.name.clone(), a);
+                    Ok(())
+                }
+                '@' => {
+                    let (n, f) = parse_format(line, &fields, width)?;
+                    formats.insert(n, f);
+                    Ok(())
+                }
+                '{' | '}' | '[' | ']' => Ok(()),
+                _ => {
+                    let p = parse_pattern(
+                        line,
+                        &formats,
+                        &fields,
+                        &mut auto_args,
+                        width,
+                    )?;
+                    patterns.push(p);
+                    Ok(())
+                }
             }
-            '&' => {
-                let a = parse_argset(line)?;
-                argsets.insert(a.name.clone(), a);
-                Ok(())
-            }
-            '@' => {
-                let (n, f) = parse_format(line, &fields, width)?;
-                formats.insert(n, f);
-                Ok(())
-            }
-            '{' | '}' | '[' | ']' => Ok(()),
-            _ => {
-                let p = parse_pattern(
-                    line,
-                    &formats,
-                    &fields,
-                    &mut auto_args,
-                    width,
-                )?;
-                patterns.push(p);
-                Ok(())
-            }
-        };
+        })();
         result.map_err(|e: String| format!("line {}: {e}", lineno + 1))?;
     }
     argsets.extend(auto_args);
+
+    // Final pass: validate every pattern's `&argset` reference
+    // resolves to a defined or auto-generated argset. Without this
+    // check an unknown argset name would slip silently through to
+    // codegen and surface as a Rust type error.
+    for p in &patterns {
+        if !p.args_name.is_empty() && !argsets.contains_key(&p.args_name) {
+            return Err(format!(
+                "unknown argset &{} referenced by pattern {}",
+                p.args_name, p.name,
+            ));
+        }
+    }
+
     Ok(Parsed {
         fields,
         argsets,

--- a/tests/src/decode/mod.rs
+++ b/tests/src/decode/mod.rs
@@ -90,7 +90,11 @@ fn bit_pattern_inline_fields() {
 #[test]
 fn bit_pattern_exceeds_32() {
     let toks = ["11111111111111111111111111111111", "1"];
-    assert!(parse_bit_tokens(&toks, 32).is_err());
+    let err = parse_bit_tokens(&toks, 32).unwrap_err();
+    assert!(
+        err.contains("exceeds") && err.contains("32"),
+        "error must mention overflow and width 32, got: {err}",
+    );
 }
 
 // ── Field parsing ────────────────────────────────────────────
@@ -140,9 +144,23 @@ fn parse_field_with_function() {
 
 #[test]
 fn parse_bad_field_segment() {
-    assert!(parse_field_segment("abc").is_err());
-    assert!(parse_field_segment(":5").is_err());
-    assert!(parse_field_segment("20:").is_err());
+    let e1 = parse_field_segment("abc").unwrap_err();
+    assert!(
+        e1.contains("bad segment") && e1.contains("abc"),
+        "missing-colon error must echo the bad token, got: {e1}",
+    );
+
+    let e2 = parse_field_segment(":5").unwrap_err();
+    assert!(
+        e2.contains("bad pos"),
+        "empty position must be flagged as bad pos, got: {e2}",
+    );
+
+    let e3 = parse_field_segment("20:").unwrap_err();
+    assert!(
+        e3.contains("bad len"),
+        "empty length must be flagged as bad len, got: {e3}",
+    );
 }
 
 // ── Argset parsing ───────────────────────────────────────────
@@ -304,7 +322,89 @@ fn parse_unknown_format_ref() {
 @r ....... ..... ..... ... ..... ....... &r %rd
 add 0000000 ..... ..... 000 ..... 0110011 @nonexistent
 ";
-    assert!(parse(input).is_err());
+    let err = parse(input).unwrap_err();
+    assert!(
+        err.contains("unknown format") && err.contains("nonexistent"),
+        "error must name the missing format, got: {err}",
+    );
+    // The top-level wrapper must add line context so the user sees
+    // which line of the .decode input is at fault.
+    assert!(
+        err.contains("line "),
+        "error must include line number, got: {err}",
+    );
+}
+
+#[test]
+fn parse_unknown_argset_ref_is_rejected() {
+    let input = "\
+%rd 7:5
+add 0000000 ..... ..... 000 ..... 0110011 &nope %rd
+";
+    let err = parse(input).unwrap_err();
+    assert!(
+        err.contains("unknown argset") && err.contains("nope"),
+        "error must name the missing argset, got: {err}",
+    );
+    assert!(
+        err.contains("add"),
+        "error should also point at the referencing pattern, got: {err}",
+    );
+}
+
+#[test]
+fn parse_bit_pattern_overflow_includes_line_number() {
+    // Pattern with 33 bit characters in a 32-bit decoder. The
+    // error must round-trip through parse_with_width's
+    // `line {N}: ...` wrapper.
+    let input = "\
+# leading comment
+foo 11111111111111111111111111111111 1
+";
+    let err = parse(input).unwrap_err();
+    assert!(
+        err.contains("exceeds") && err.contains("32"),
+        "error must describe the overflow and width, got: {err}",
+    );
+    assert!(
+        err.contains("line "),
+        "error must carry a line number prefix, got: {err}",
+    );
+}
+
+#[test]
+fn parse_bad_field_segment_in_input_includes_line_number() {
+    // %rd has a malformed segment ":5" — empty position. The
+    // error from parse_field_segment must surface with line info.
+    let input = "\
+# header
+%rd :5
+";
+    let err = parse(input).unwrap_err();
+    assert!(
+        err.contains("bad pos"),
+        "underlying segment error must surface, got: {err}",
+    );
+    assert!(
+        err.contains("line "),
+        "error must include line number, got: {err}",
+    );
+}
+
+#[test]
+fn parse_bad_attr_includes_concrete_token() {
+    // `xyz=blah` is not parseable as either a `%field` ref or an
+    // integer constant.
+    let input = "\
+%rd 7:5
+&r rd
+add 0000000 ..... ..... 000 ..... 0110011 &r %rd xyz=blah
+";
+    let err = parse(input).unwrap_err();
+    assert!(
+        err.contains("bad attr") && err.contains("xyz=blah"),
+        "error must echo the bad attr token, got: {err}",
+    );
 }
 
 // ── Format inheritance ───────────────────────────────────────


### PR DESCRIPTION
Resolves gevico/machina#73.

## What

Two real parser issues plus a documentation/testing pass on top.

### Bug 1: line-number prefix was being bypassed

\`parse_with_width\`'s per-line dispatch contained:

\`\`\`rust
let result: Result<(), String> = match first {
    '%' => { let f = parse_field(line)?; ... Ok(()) }
    ...
};
result.map_err(|e| format!(\"line {N}: {e}\", lineno + 1))?;
\`\`\`

\`?\` inside an arm body propagates from the enclosing function,
not the surrounding block, so errors short-circuited past the
\`map_err\` and the user never saw a line number. Wrapping the
dispatch in an immediately-invoked closure routes the \`?\` back
through \`result\` and the line prefix is now reliably attached.

### Bug 2: unknown \`&argset\` references slipped through

Pattern arg-set references were never validated against the
defined / auto-generated argsets. An unknown name silently
flowed into codegen and surfaced as a Rust type error far from
the cause. Add a final pass after the parse loop that rejects
\`unknown argset &<name> referenced by pattern <pat>\`.

### Boilerplate: Debug on Parsed / BitPatternResult

Needed so callers and tests can use \`unwrap_err\` / standard
Result helpers.

## Tests

\`tests/src/decode/mod.rs\`:

- Strengthened \`bit_pattern_exceeds_32\` and
  \`parse_bad_field_segment\` from \`is_err()\` into keyword
  matches.
- Strengthened \`parse_unknown_format_ref\` to assert both the
  format name AND the line-number prefix.
- New \`parse_unknown_argset_ref_is_rejected\`.
- New \`parse_bit_pattern_overflow_includes_line_number\` — this
  one was previously *not* failing meaningfully because of bug 1.
- New \`parse_bad_field_segment_in_input_includes_line_number\`.
- New \`parse_bad_attr_includes_concrete_token\`.

## Test plan

- [x] \`cargo test -p machina-tests decode\` — 169 passed (existing decode + loongarch_decode codegen tests included).
- [x] \`make fmt-check\` clean.
- [x] \`make clippy\` clean.