### PR TITLE
hw/virtio: route ring access through checked arithmetic (#58)

### DIFF
--- a/hw/virtio/src/block.rs
+++ b/hw/virtio/src/block.rs
@@ -273,12 +273,13 @@ impl VirtioDevice for VirtioBlk {
     ) -> u32 {
         let avail_idx = queue.read_avail_idx(ram, ram_base, ram_size);
         let mut processed = 0u32;
-        let mut used_idx = {
-            let off = queue.used_addr + 2 - ram_base;
-            if off + 2 > ram_size {
-                return 0;
-            }
-            unsafe { (ram.add(off as usize) as *const u16).read_unaligned() }
+        // Delegate the used.idx read to VirtQueue so the bounds
+        // checks live next to the rest of the ring arithmetic
+        // and a bad guest used_addr cannot wrap into a huge
+        // host-side offset here.
+        let mut used_idx = match queue.read_used_idx(ram, ram_base, ram_size) {
+            Some(v) => v,
+            None => return 0,
         };
 
         while queue.last_avail_idx != avail_idx {

--- a/hw/virtio/src/queue.rs
+++ b/hw/virtio/src/queue.rs
@@ -98,6 +98,28 @@ impl VirtQueue {
         unsafe { (ram.add(off as usize) as *const u16).read_unaligned() }
     }
 
+    /// Translate a ring offset to a host-RAM offset, returning
+    /// `None` if any of the additions or subtractions wrap or
+    /// the resulting `[off, off + len)` window leaves
+    /// `[0, ram_size)`. Used by every ring access path so a
+    /// malicious or stale guest address can never reach the
+    /// raw pointer arithmetic below.
+    fn ring_off(
+        base_addr: u64,
+        offset: u64,
+        len: u64,
+        ram_base: u64,
+        ram_size: u64,
+    ) -> Option<u64> {
+        let addr = base_addr.checked_add(offset)?;
+        let off = addr.checked_sub(ram_base)?;
+        let end = off.checked_add(len)?;
+        if end > ram_size {
+            return None;
+        }
+        Some(off)
+    }
+
     /// Read an entry from the available ring.
     ///
     /// # Safety
@@ -114,11 +136,39 @@ impl VirtQueue {
             return 0;
         }
         let i = (ring_idx as u64) % (self.num as u64);
-        let off = self.avail_addr + 4 + i * 2 - ram_base;
-        if off + 2 > ram_size {
-            return 0;
-        }
+        // avail.ring[i] at avail_addr + 4 + i*2.
+        let entry_offset = match i.checked_mul(2).and_then(|e| e.checked_add(4))
+        {
+            Some(o) => o,
+            None => return 0,
+        };
+        let off = match Self::ring_off(
+            self.avail_addr,
+            entry_offset,
+            2,
+            ram_base,
+            ram_size,
+        ) {
+            Some(o) => o,
+            None => return 0,
+        };
         unsafe { (ram.add(off as usize) as *const u16).read_unaligned() }
+    }
+
+    /// Read the used ring index (used.idx). Returns `None` if
+    /// the configured `used_addr` is out of range.
+    ///
+    /// # Safety
+    /// Caller must ensure `ram` is valid for the range
+    /// [`ram_base`, `ram_base + ram_size`).
+    pub unsafe fn read_used_idx(
+        &self,
+        ram: *const u8,
+        ram_base: u64,
+        ram_size: u64,
+    ) -> Option<u16> {
+        let off = Self::ring_off(self.used_addr, 2, 2, ram_base, ram_size)?;
+        Some(unsafe { (ram.add(off as usize) as *const u16).read_unaligned() })
     }
 
     /// Write an entry to the used ring.
@@ -140,10 +190,21 @@ impl VirtQueue {
         }
         let i = (used_idx as u64) % (self.num as u64);
         // used.ring[i] at used_addr + 4 + i*8.
-        let off = self.used_addr + 4 + i * 8 - ram_base;
-        if off + 8 > ram_size {
-            return;
-        }
+        let entry_offset = match i.checked_mul(8).and_then(|e| e.checked_add(4))
+        {
+            Some(o) => o,
+            None => return,
+        };
+        let off = match Self::ring_off(
+            self.used_addr,
+            entry_offset,
+            8,
+            ram_base,
+            ram_size,
+        ) {
+            Some(o) => o,
+            None => return,
+        };
         unsafe {
             let p = ram.add(off as usize);
             (p as *mut u32).write_unaligned(desc_id);
@@ -163,10 +224,11 @@ impl VirtQueue {
         ram_base: u64,
         ram_size: u64,
     ) {
-        let off = self.used_addr + 2 - ram_base;
-        if off + 2 > ram_size {
-            return;
-        }
+        let off = match Self::ring_off(self.used_addr, 2, 2, ram_base, ram_size)
+        {
+            Some(o) => o,
+            None => return,
+        };
         unsafe {
             (ram.add(off as usize) as *mut u16).write_unaligned(idx);
         }

--- a/tests/src/virtio.rs
+++ b/tests/src/virtio.rs
@@ -372,3 +372,98 @@ fn test_queue1_notify_dispatches_handle_queue() {
         "wrong queue index dispatched"
     );
 }
+
+// ===== VirtQueue ring address bounds (#58) =====
+//
+// All ring access paths must reject out-of-range / underflowing
+// guest addresses without panicking, even in debug builds. These
+// tests configure a queue with a bad avail_addr or used_addr and
+// drive the unsafe entry points; the host RAM buffer is filled
+// with a sentinel so any accidental write would be visible.
+
+unsafe fn ring_test_buf() -> Vec<u8> {
+    vec![0xA5u8; 4096]
+}
+
+#[test]
+fn read_avail_ring_with_avail_addr_below_ram_base_returns_zero_no_panic() {
+    let mut q = VirtQueue::new();
+    q.num = 16;
+    // ram_base = 0x10000, avail_addr = 0x100 < ram_base.
+    q.avail_addr = 0x100;
+    let buf = unsafe { ring_test_buf() };
+    let got = unsafe {
+        q.read_avail_ring(0, buf.as_ptr(), 0x10000, buf.len() as u64)
+    };
+    assert_eq!(got, 0, "underflowing avail_addr must return 0");
+    // The buffer must be untouched (it's read-only here, but
+    // double-check no out-of-bounds host access scribbled it).
+    assert!(buf.iter().all(|&b| b == 0xA5));
+}
+
+#[test]
+fn read_avail_ring_with_overflowing_addr_returns_zero_no_panic() {
+    let mut q = VirtQueue::new();
+    q.num = 16;
+    // avail_addr near u64 max so + 4 + i*2 overflows.
+    q.avail_addr = u64::MAX - 1;
+    let buf = unsafe { ring_test_buf() };
+    let got =
+        unsafe { q.read_avail_ring(0, buf.as_ptr(), 0, buf.len() as u64) };
+    assert_eq!(got, 0, "overflowing avail_addr arithmetic must return 0");
+}
+
+#[test]
+fn write_used_with_used_addr_below_ram_base_is_a_noop_no_panic() {
+    let mut q = VirtQueue::new();
+    q.num = 16;
+    q.used_addr = 0x80; // below ram_base.
+    let mut buf = unsafe { ring_test_buf() };
+    unsafe {
+        q.write_used(0, 1, 4, buf.as_mut_ptr(), 0x10000, buf.len() as u64);
+    }
+    assert!(
+        buf.iter().all(|&b| b == 0xA5),
+        "underflowing used_addr must not write any host memory",
+    );
+}
+
+#[test]
+fn write_used_idx_with_used_addr_below_ram_base_is_a_noop_no_panic() {
+    let mut q = VirtQueue::new();
+    q.used_addr = 0x80; // below ram_base.
+    let mut buf = unsafe { ring_test_buf() };
+    unsafe {
+        q.write_used_idx(7, buf.as_mut_ptr(), 0x10000, buf.len() as u64);
+    }
+    assert!(
+        buf.iter().all(|&b| b == 0xA5),
+        "underflowing used_addr must not write the index",
+    );
+}
+
+#[test]
+fn read_used_idx_returns_none_for_underflowing_used_addr() {
+    let mut q = VirtQueue::new();
+    q.used_addr = 0x80;
+    let buf = unsafe { ring_test_buf() };
+    let got =
+        unsafe { q.read_used_idx(buf.as_ptr(), 0x10000, buf.len() as u64) };
+    assert!(got.is_none(), "underflowing used_addr must surface as None");
+}
+
+#[test]
+fn read_used_idx_returns_value_for_in_range_addr() {
+    // ram_base = 0x1000, ram_size = 0x1000, used_addr = 0x1100.
+    // used.idx is at used_addr + 2 = 0x1102 -> off = 0x102.
+    // Pre-write 0x1234 there.
+    let mut buf = unsafe { ring_test_buf() };
+    let off: usize = 0x102;
+    buf[off] = 0x34;
+    buf[off + 1] = 0x12;
+
+    let mut q = VirtQueue::new();
+    q.used_addr = 0x1100;
+    let got = unsafe { q.read_used_idx(buf.as_ptr(), 0x1000, 0x1000) };
+    assert_eq!(got, Some(0x1234));
+}


### PR DESCRIPTION
Resolves gevico/machina#58.

## What

Three \`VirtQueue\` ring-access paths used unchecked arithmetic on
guest-supplied addresses:

\`\`\`rust
let off = self.avail_addr + 4 + i * 2 - ram_base;   // read_avail_ring
let off = self.used_addr  + 4 + i * 8 - ram_base;   // write_used
let off = self.used_addr  + 2 - ram_base;           // write_used_idx
\`\`\`

If the guest set \`avail_addr\` / \`used_addr\` below \`ram_base\`,
these wrapped to a very large \`off\`; the subsequent \`off + N >
ram_size\` check itself wraps when \`off\` sits near \`u64::MAX\`.
Debug builds panicked; release builds risked out-of-bounds host
pointer arithmetic. \`block.rs::handle_queue\` reproduced the
exact same fragile snippet inline.

### Refactor

- Add \`VirtQueue::ring_off(base, offset, len, ram_base, ram_size)
  -> Option<u64>\` running \`checked_add\`/\`checked_sub\` and an
  \`end <= ram_size\` check. Every ring path goes through it.
- \`read_avail_ring\` / \`write_used\` / \`write_used_idx\` fall back
  to the documented safe behaviour (return 0 / no-op) on None.
- Add \`read_used_idx() -> Option<u16>\` so device code stops
  duplicating \`used_addr + 2 - ram_base\` inline.
- \`block.rs::handle_queue\` calls the new \`read_used_idx\`
  instead. \`net.rs\` already used checked arithmetic and is
  left untouched.

## Tests

\`tests/src/virtio.rs\`:

- \`read_avail_ring_with_avail_addr_below_ram_base_returns_zero_no_panic\`
- \`read_avail_ring_with_overflowing_addr_returns_zero_no_panic\`
- \`write_used_with_used_addr_below_ram_base_is_a_noop_no_panic\`
- \`write_used_idx_with_used_addr_below_ram_base_is_a_noop_no_panic\`
- \`read_used_idx_returns_none_for_underflowing_used_addr\`
- \`read_used_idx_returns_value_for_in_range_addr\`

A 4 KiB host buffer is pre-filled with \`0xA5\` so any accidental
write would be visible.

## Test plan

- [x] \`cargo test -p machina-tests virtio\` — 25 passed (19 existing + 6 new), debug build, no panics.
- [x] \`make fmt-check\` clean.
- [x] \`make clippy\` clean.