### PR TITLE
util: document trace multithreading and pin behaviour (#66)

### DIFF
--- a/tests/src/trace.rs
+++ b/tests/src/trace.rs
@@ -51,3 +51,124 @@ fn test_trace_init_bad_path() {
     let result = trace::init_trace("/nonexistent/dir/trace.log");
     assert!(result.is_err());
 }
+
+// ===== Multithreaded behaviour (#66) =====
+//
+// The trace destination is per-thread; trace_enabled() is a
+// global gate. The tests below pin down both halves: an
+// uninitialised child thread must never write to whatever file
+// the main thread opened, and two threads that init separately
+// must each receive their own events.
+
+#[test]
+fn test_trace_uninit_child_does_not_write_to_main_thread_file() {
+    let dir = tempfile::tempdir().unwrap();
+    let main_path = dir.path().join("main.log");
+
+    trace::init_trace(main_path.to_str().unwrap()).unwrap();
+    assert!(trace::trace_enabled());
+
+    // Spawn a child that only emits trace events, without
+    // calling init_trace itself. The global ENABLED flag is
+    // already on, so trace_enabled() is true, but the child's
+    // thread-local TRACE_FILE is None — events must drop.
+    let main_path_for_child = main_path.clone();
+    let handle = std::thread::spawn(move || {
+        assert!(trace::trace_enabled());
+        trace::trace_csr("child_csr", 0xDEAD_BEEF);
+        trace::trace_exception(7, 0x4000_0000);
+        trace::trace_mmio(0x9000_0000, 4, 0xCAFE, true);
+        // Sanity: the main thread's file is untouched while the
+        // child runs (we only wrote child events).
+        let mut s = String::new();
+        std::fs::File::open(&main_path_for_child)
+            .unwrap()
+            .read_to_string(&mut s)
+            .unwrap();
+        assert!(
+            !s.contains("child_csr"),
+            "child trace events leaked into main thread file: {s}",
+        );
+    });
+    handle.join().unwrap();
+
+    // Now exercise main thread's own trace file: should still
+    // be functional and not contain any child markers.
+    trace::trace_csr("main_csr", 1);
+    let mut s = String::new();
+    std::fs::File::open(&main_path)
+        .unwrap()
+        .read_to_string(&mut s)
+        .unwrap();
+    assert!(s.contains("main_csr"));
+    assert!(!s.contains("child_csr"));
+    assert!(!s.contains("DEAD_BEEF") && !s.contains("dead_beef"));
+}
+
+#[test]
+fn test_trace_two_threads_write_to_their_own_files() {
+    let dir = tempfile::tempdir().unwrap();
+    let path_a = dir.path().join("thread_a.log");
+    let path_b = dir.path().join("thread_b.log");
+
+    let pa = path_a.clone();
+    let ha = std::thread::spawn(move || {
+        trace::init_trace(pa.to_str().unwrap()).unwrap();
+        trace::trace_csr("aaa", 0x1111);
+    });
+    let pb = path_b.clone();
+    let hb = std::thread::spawn(move || {
+        trace::init_trace(pb.to_str().unwrap()).unwrap();
+        trace::trace_csr("bbb", 0x2222);
+    });
+    ha.join().unwrap();
+    hb.join().unwrap();
+
+    let mut sa = String::new();
+    std::fs::File::open(&path_a)
+        .unwrap()
+        .read_to_string(&mut sa)
+        .unwrap();
+    let mut sb = String::new();
+    std::fs::File::open(&path_b)
+        .unwrap()
+        .read_to_string(&mut sb)
+        .unwrap();
+
+    assert!(sa.contains("aaa"));
+    assert!(!sa.contains("bbb"));
+    assert!(sb.contains("bbb"));
+    assert!(!sb.contains("aaa"));
+}
+
+#[test]
+fn test_trace_enabled_global_but_uninit_thread_drops_events() {
+    // This test asserts the contract for trace_enabled():
+    // returning true does NOT mean the calling thread has a
+    // file open. A child thread that never calls init_trace
+    // sees trace_enabled() == true (because the main thread or
+    // a sibling has enabled tracing) but its own trace_*
+    // calls are no-ops.
+    let dir = tempfile::tempdir().unwrap();
+    let main_path = dir.path().join("global.log");
+    trace::init_trace(main_path.to_str().unwrap()).unwrap();
+
+    let h = std::thread::spawn(|| {
+        // No init here.
+        let was_enabled = trace::trace_enabled();
+        trace::trace_csr("ghost", 0xFF);
+        was_enabled
+    });
+    let was_enabled = h.join().unwrap();
+    assert!(
+        was_enabled,
+        "child should have observed the global ENABLED flag",
+    );
+
+    let mut s = String::new();
+    std::fs::File::open(&main_path)
+        .unwrap()
+        .read_to_string(&mut s)
+        .unwrap();
+    assert!(!s.contains("ghost"), "uninit child events must not surface");
+}

--- a/util/src/trace.rs
+++ b/util/src/trace.rs
@@ -1,4 +1,21 @@
-// Thread-local event tracer for debugging and analysis.
+//! Thread-local event tracer for debugging and analysis.
+//!
+//! ## Multithreading model
+//!
+//! - The "tracing is active" gate is a single global atomic
+//!   ([`ENABLED`]); this gives a fast path for trace points on
+//!   threads that have not opted in.
+//! - The trace *destination* is per-thread: every public
+//!   `trace_*` function writes to the calling thread's
+//!   [`TRACE_FILE`]. A thread that has not called
+//!   [`init_trace`] has no destination, so its trace calls are
+//!   silently dropped even when [`trace_enabled`] reports true
+//!   because some *other* thread enabled tracing.
+//! - As a consequence, [`trace_enabled`] only tells you whether
+//!   *some* thread has initialised tracing; it does not imply
+//!   that the calling thread will produce output. To trace
+//!   events from multiple threads, every participating thread
+//!   must call [`init_trace`] with its own path.
 
 use std::cell::RefCell;
 use std::fs::File;
@@ -12,9 +29,13 @@ thread_local! {
         const { RefCell::new(None) };
 }
 
-/// Open a trace file for the current thread and enable
-/// tracing globally. Each thread should call this with its
-/// own path if multi-thread tracing is desired.
+/// Open a trace file for the **current thread** and enable
+/// tracing globally.
+///
+/// Each thread that should produce output must call this on
+/// itself with its own path; the trace destination is a
+/// thread-local. Calling `init_trace` on the main thread does
+/// not retroactively configure child threads.
 ///
 /// # Errors
 ///
@@ -28,9 +49,14 @@ pub fn init_trace(path: &str) -> std::io::Result<()> {
     Ok(())
 }
 
-/// Fast check whether tracing is active. Returns false when
-/// no thread has called `init_trace`, making the cost of an
-/// unconfigured trace point a single relaxed atomic load.
+/// Fast check whether *some* thread has enabled tracing.
+///
+/// Returns `false` when no thread has ever called
+/// [`init_trace`], making the cost of an unconfigured trace
+/// point a single relaxed atomic load. A `true` result does
+/// **not** mean the calling thread has a trace file open: a
+/// thread that has not called [`init_trace`] still drops its
+/// own trace events even when this returns `true`.
 #[inline]
 pub fn trace_enabled() -> bool {
     ENABLED.load(Ordering::Relaxed)


### PR DESCRIPTION
Resolves gevico/machina#66.

## What

Make the trace module's two-axis design (global ENABLED gate +
per-thread TRACE_FILE) explicit in rustdoc and lock its
multithreaded behaviour with regression tests. No production
behaviour changes.

### Doc updates (\`util/src/trace.rs\`)

- Module-level rustdoc spells out the model: a single global
  atomic gate for the fast path, plus a thread-local trace
  destination. \`trace_enabled() == true\` does **not** imply
  the calling thread will produce output.
- \`init_trace\` doc now says the current thread, and that a
  spawned child does not inherit configuration.
- \`trace_enabled\` doc warns that a true return only means
  *some* thread has initialised tracing.

### New tests (\`tests/src/trace.rs\`)

| Test | What it pins down |
|------|-------------------|
| \`test_trace_uninit_child_does_not_write_to_main_thread_file\` | Child thread sees \`trace_enabled() == true\` after main inits, but its trace events do not surface in the main file. |
| \`test_trace_two_threads_write_to_their_own_files\` | Two threads with separate \`init_trace\` paths each receive only their own events. |
| \`test_trace_enabled_global_but_uninit_thread_drops_events\` | Asserts the precise contract: \`trace_enabled()\` is necessary but not sufficient for an uninitialised thread to produce output. |

All tests use \`tempfile\` so nothing escapes to a fixed host path.

## Test plan

- [x] \`cargo test -p machina-tests trace\` — 7 passed (4 existing + 3 new).
- [x] \`make fmt-check\` clean.
- [x] \`make clippy\` clean.