### PR TITLE
tests: add monitor snapshot and protocol-error coverage (#60)

### DIFF
--- a/tests/src/monitor.rs
+++ b/tests/src/monitor.rs
@@ -2,7 +2,7 @@ use std::io::{BufRead, BufReader, Write};
 use std::net::TcpStream;
 use std::sync::{Arc, Mutex};
 
-use machina_core::monitor::{MonitorState, VmState};
+use machina_core::monitor::{CpuSnapshot, MonitorState, VmState};
 use machina_monitor::hmp;
 use machina_monitor::mmp;
 use machina_monitor::service::MonitorService;
@@ -333,4 +333,188 @@ fn test_hmp_interactive_session() {
     assert!(text.contains("VM status: running"));
     assert!(text.contains("info status"));
     assert!(text.contains("(machina)"));
+}
+
+// ===== Snapshot and error-path coverage (#60) =====
+//
+// Each pause-aware test spawns a dedicated polling thread that
+// runs `check_pause` until quit is requested, mirroring the
+// existing MonitorState tests. The thread always exits via
+// `request_quit` so the test cannot hang on a stale handle.
+
+fn pause_polling_thread(
+    state: Arc<MonitorState>,
+) -> std::thread::JoinHandle<()> {
+    std::thread::spawn(move || {
+        while !state.check_pause() {
+            std::thread::sleep(std::time::Duration::from_millis(1));
+        }
+    })
+}
+
+#[test]
+fn test_hmp_info_registers_dumps_gprs_and_pc_when_paused() {
+    let svc = make_svc();
+    let state = Arc::clone(&svc.lock().unwrap().state);
+    let h = pause_polling_thread(Arc::clone(&state));
+    std::thread::sleep(std::time::Duration::from_millis(20));
+
+    state.request_stop();
+    let mut snap = CpuSnapshot {
+        pc: 0x8000_1234,
+        ..Default::default()
+    };
+    snap.gpr[1] = 0xDEAD_BEEF;
+    snap.gpr[2] = 0x1000_0000;
+    state.store_snapshot(snap);
+
+    let out = hmp::handle_line("info registers", &svc).unwrap();
+    assert!(out.contains(" x0 "));
+    assert!(out.contains(" x31 "));
+    assert!(out.contains(" pc "));
+    assert!(
+        out.contains("0x00000000deadbeef"),
+        "register dump should include x1 = DEADBEEF, got: {out}",
+    );
+    assert!(
+        out.contains("0x0000000080001234"),
+        "register dump should include pc = 0x80001234, got: {out}",
+    );
+
+    state.request_quit();
+    h.join().unwrap();
+}
+
+#[test]
+fn test_hmp_info_cpus_paused_reports_snapshot_pc_and_state() {
+    let svc = make_svc();
+    let state = Arc::clone(&svc.lock().unwrap().state);
+    let h = pause_polling_thread(Arc::clone(&state));
+    std::thread::sleep(std::time::Duration::from_millis(20));
+
+    state.request_stop();
+    state.store_snapshot(CpuSnapshot {
+        pc: 0xc000_0010,
+        halted: true,
+        ..Default::default()
+    });
+
+    let out = hmp::handle_line("info cpus", &svc).unwrap();
+    assert!(out.contains("CPU #0"));
+    assert!(
+        out.contains("pc=0xc0000010"),
+        "info cpus should print snapshot PC when paused, got: {out}",
+    );
+    assert!(
+        out.contains("halted"),
+        "info cpus should mark halted snapshots, got: {out}",
+    );
+
+    state.request_quit();
+    h.join().unwrap();
+}
+
+#[test]
+fn test_tcp_invalid_json_returns_generic_error() {
+    if !tcp_bind_available() {
+        eprintln!("skipping: TCP bind not permitted");
+        return;
+    }
+    let state = Arc::new(MonitorState::new());
+    let svc = Arc::new(Mutex::new(MonitorService::new(Arc::clone(&state))));
+    let listener = std::net::TcpListener::bind("127.0.0.1:0").unwrap();
+    let addr = listener.local_addr().unwrap();
+
+    let svc2 = Arc::clone(&svc);
+    let handle = std::thread::spawn(move || mmp::run_tcp(listener, svc2));
+
+    let stream = TcpStream::connect(addr).unwrap();
+    stream
+        .set_read_timeout(Some(std::time::Duration::from_secs(3)))
+        .unwrap();
+    let mut reader = BufReader::new(stream.try_clone().unwrap());
+    let mut writer = stream;
+
+    let _greeting = read_json_line(&mut reader);
+
+    // Caps first so caps-gating doesn't shadow the JSON-parse error.
+    send_cmd(&mut writer, "qmp_capabilities");
+    let _ = read_json_line(&mut reader);
+
+    // Malformed JSON: missing closing brace.
+    writeln!(&mut writer, "{{not json").unwrap();
+    writer.flush().unwrap();
+
+    let resp = read_json_line(&mut reader);
+    assert_eq!(resp["error"]["class"], "GenericError");
+    assert!(
+        resp["error"]["desc"]
+            .as_str()
+            .unwrap_or("")
+            .contains("JSON parse error"),
+        "GenericError desc must mention JSON parse error, got {resp}",
+    );
+
+    // Subsequent valid command must still work — the bad line
+    // did not poison the connection.
+    send_cmd(&mut writer, "query-status");
+    let resp = read_json_line(&mut reader);
+    assert_eq!(resp["return"]["running"], true);
+
+    send_cmd(&mut writer, "quit");
+    let _ = read_json_line(&mut reader);
+    handle.join().unwrap();
+}
+
+#[test]
+fn test_tcp_blank_lines_then_unknown_command_after_caps() {
+    if !tcp_bind_available() {
+        eprintln!("skipping: TCP bind not permitted");
+        return;
+    }
+    let state = Arc::new(MonitorState::new());
+    let svc = Arc::new(Mutex::new(MonitorService::new(Arc::clone(&state))));
+    let listener = std::net::TcpListener::bind("127.0.0.1:0").unwrap();
+    let addr = listener.local_addr().unwrap();
+
+    let svc2 = Arc::clone(&svc);
+    let handle = std::thread::spawn(move || mmp::run_tcp(listener, svc2));
+
+    let stream = TcpStream::connect(addr).unwrap();
+    stream
+        .set_read_timeout(Some(std::time::Duration::from_secs(3)))
+        .unwrap();
+    let mut reader = BufReader::new(stream.try_clone().unwrap());
+    let mut writer = stream;
+
+    let _greeting = read_json_line(&mut reader);
+
+    // Blank lines before caps must be silently skipped.
+    writeln!(&mut writer).unwrap();
+    writeln!(&mut writer, "   ").unwrap();
+    writer.flush().unwrap();
+
+    send_cmd(&mut writer, "qmp_capabilities");
+    let _ = read_json_line(&mut reader);
+
+    // Blank lines after caps too.
+    writeln!(&mut writer).unwrap();
+    writer.flush().unwrap();
+
+    // Unknown post-caps command returns CommandNotFound, not
+    // CommandNotFound-because-of-caps.
+    send_cmd(&mut writer, "no-such-cmd");
+    let resp = read_json_line(&mut reader);
+    assert_eq!(resp["error"]["class"], "CommandNotFound");
+    assert!(
+        resp["error"]["desc"]
+            .as_str()
+            .unwrap_or("")
+            .contains("no-such-cmd"),
+        "CommandNotFound desc must echo the command, got {resp}",
+    );
+
+    send_cmd(&mut writer, "quit");
+    let _ = read_json_line(&mut reader);
+    handle.join().unwrap();
 }


### PR DESCRIPTION
Resolves gevico/machina#60.

## What

Cover the snapshot and error-path scenarios #60 calls out on top
of the existing happy-path monitor suite. No production code
changes — current monitor behaviour matches the spec, these tests
lock it in.

### New cases

| Test | What it pins down |
|------|-------------------|
| \`test_hmp_info_registers_dumps_gprs_and_pc_when_paused\` | After parking the VM and storing a CpuSnapshot, \`info registers\` produces x0..x31 plus pc with zero-padded hex (verified for x1=DEADBEEF and pc=0x80001234). |
| \`test_hmp_info_cpus_paused_reports_snapshot_pc_and_state\` | When paused, \`info cpus\` prints the snapshot's pc (0xc0000010) and "halted". |
| \`test_tcp_invalid_json_returns_generic_error\` | Malformed JSON after caps returns \`{"class":"GenericError","desc":"JSON parse error..."}\`; the connection is not poisoned and \`query-status\` still works after. |
| \`test_tcp_blank_lines_then_unknown_command_after_caps\` | Blank lines before and after caps are silently ignored; an unknown post-caps command returns \`CommandNotFound\` with the bad name echoed. |

### Pause/condvar safety

The two HMP tests use a small \`pause_polling_thread\` helper that
spawns an exec-loop poll thread and is torn down with
\`request_quit\` so no test can hang on a stale Condvar.

### TCP test hygiene

All TCP tests bind to \`127.0.0.1:0\` and use a 3-second read
timeout so a regression cannot block CI.

## Test plan

- [x] \`cargo test -p machina-tests monitor\` — 27 passed (23 existing + 4 new).
- [x] \`make fmt-check\` clean.
- [x] \`make clippy\` clean.