### PR TITLE
docs: add reproducible first-time-contributor guide (#63)

### DIFF
--- a/docs/en/getting-started.md
+++ b/docs/en/getting-started.md
@@ -3,6 +3,104 @@
 > Target audience: developers who want to build, run, and boot
 > guest software on machina.
 
+## First-time Contributor Walk-through
+
+This path uses only the firmware payloads bundled in
+`tests/firmware/`, so it works on a fresh clone with no external
+kernel, disk image, or RISC-V cross toolchain. Run each step in
+order; if a step fails see [Troubleshooting](#troubleshooting).
+
+### 1. Install host dependencies
+
+- A current stable Rust toolchain (`rustc 1.80+`) plus `cargo`,
+  installed via [`rustup`](https://rustup.rs/).
+- GNU `make`.
+- A working host C linker (`cc`) — Cargo invokes it for the
+  release build.
+
+### 2. Clone and build
+
+```bash
+git clone https://github.com/gevico/machina.git
+cd machina
+make release
+```
+
+The first build also pulls workspace dependencies (~1–3 minutes
+on a recent laptop). The output binary is at
+`./target/release/machina`.
+
+### 3. Smoke-boot a bundled payload
+
+The cheapest end-to-end check — boots the bundled bare-metal
+"PASS" kernel against `riscv64-ref` and exits with code 0:
+
+```bash
+./target/release/machina -M riscv64-ref -m 128 -bios none \
+    -kernel tests/firmware/sifive_pass.bin -nographic
+```
+
+Expected output (the `shutdown (pass)` line is the success
+marker):
+
+```
+machina: riscv64-ref, 128 MiB RAM
+machina: entering execution loop
+machina: shutdown (pass)
+```
+
+For a longer smoke test that exercises the bundled RustSBI
+firmware path, run:
+
+```bash
+./target/release/machina -M riscv64-ref -m 128 \
+    -kernel tests/firmware/sbi_smoke.bin -nographic
+```
+
+Expected output begins with the RustSBI banner and ends with
+`MACHINA_SBI_OK`, after which Machina exits cleanly.
+
+### 4. Run the narrow tests for the area you are touching
+
+Always start with a focused filter so iteration is fast — `make
+test` runs the full suite (slow). Examples:
+
+```bash
+# Smoke tests for the boot tooling itself.
+cargo test -p machina-tests tools::
+
+# Disassembler regressions.
+cargo test -p machina-tests disas
+
+# Memory-region / FlatView tests.
+cargo test -p machina-tests memory_region
+
+# RISC-V CSR semantics.
+cargo test -p machina-tests riscv_csr
+```
+
+### 5. Pre-PR checks
+
+Before opening a pull request, the same checks CI runs:
+
+```bash
+make fmt-check    # rustfmt diff must be empty
+make clippy       # zero clippy warnings
+make test         # full test suite
+```
+
+If `.agents/` was modified, also run `make check-agent-skills`.
+
+### Troubleshooting
+
+| Symptom | Likely cause / fix |
+|---------|--------------------|
+| `make release` fails on `cc not found` | Install the host build essentials (`build-essential` on Debian/Ubuntu, Xcode CLT on macOS, `gcc` on Fedora/Arch). |
+| `tests/firmware/*.bin` missing | The repo ships pre-built binaries. If you removed them, rebuild with `cd tests/firmware && ./build.sh`, which needs a `riscv64-elf-` cross toolchain. |
+| Smoke command hangs | Make sure you used `tests/firmware/sifive_pass.bin` with `-bios none`. The plain `sifive_pass` payload is a bare-metal kernel and will not work without `-bios none`. |
+| `make test` takes a long time | This is expected — the suite is large. While iterating, prefer `cargo test -p machina-tests <filter>` and only run `make test` before pushing. |
+| `info registers` says "VM must be paused" | You are connected to a running guest. Send `stop` (HMP) or `{"execute":"stop"}` (QMP) first, then retry the query. |
+
 ## Quick Start
 
 ### Build

--- a/docs/zh/getting-started.md
+++ b/docs/zh/getting-started.md
@@ -2,6 +2,97 @@
 
 > 目标读者：希望构建、运行和引导客户软件的开发者。
 
+## 新贡献者上手流程
+
+下面这条路径仅依赖仓库自带的 `tests/firmware/` 固件，因此 fresh
+clone 之后无需准备外部内核、磁盘镜像或 RISC-V 交叉工具链就能跑通。
+按顺序执行；任意一步失败请参见末尾的「常见故障」表。
+
+### 1. 安装宿主机依赖
+
+- 当前 stable Rust 工具链（`rustc 1.80+`）以及 `cargo`，建议通过
+  [`rustup`](https://rustup.rs/) 安装。
+- GNU `make`。
+- 一个可用的宿主链接器（`cc`），release 构建时 cargo 会调用它。
+
+### 2. 克隆与构建
+
+```bash
+git clone https://github.com/gevico/machina.git
+cd machina
+make release
+```
+
+首次构建会拉取工作区依赖（在主流笔记本上约 1–3 分钟）。可执行
+文件位于 `./target/release/machina`。
+
+### 3. 用自带固件做最短的端到端冒烟
+
+最便宜的全流程检查 —— 启动自带的裸金属 PASS 内核，跑完后退出码 0：
+
+```bash
+./target/release/machina -M riscv64-ref -m 128 -bios none \
+    -kernel tests/firmware/sifive_pass.bin -nographic
+```
+
+预期输出（`shutdown (pass)` 这一行就是成功标志）：
+
+```
+machina: riscv64-ref, 128 MiB RAM
+machina: entering execution loop
+machina: shutdown (pass)
+```
+
+如果想顺带验证捆绑的 RustSBI 路径：
+
+```bash
+./target/release/machina -M riscv64-ref -m 128 \
+    -kernel tests/firmware/sbi_smoke.bin -nographic
+```
+
+输出应以 RustSBI banner 开头，并以 `MACHINA_SBI_OK` 结束，随后
+Machina 干净退出。
+
+### 4. 跑你正在改动那一块的窄测试
+
+迭代时永远先用 filter 跑窄测试，整套 `make test` 比较慢。示例：
+
+```bash
+# 启动工具自身的冒烟。
+cargo test -p machina-tests tools::
+
+# 反汇编器回归。
+cargo test -p machina-tests disas
+
+# 内存区域 / FlatView。
+cargo test -p machina-tests memory_region
+
+# RISC-V CSR 语义。
+cargo test -p machina-tests riscv_csr
+```
+
+### 5. 提 PR 之前的检查
+
+提 PR 之前，按 CI 同样的检查跑一遍：
+
+```bash
+make fmt-check    # rustfmt diff 必须为空
+make clippy       # 0 个 clippy 警告
+make test         # 全量测试套件
+```
+
+如果改动了 `.agents/`，再跑一次 `make check-agent-skills`。
+
+### 常见故障
+
+| 现象 | 大概率原因 / 修法 |
+|------|-------------------|
+| `make release` 提示 `cc not found` | 装宿主机的编译工具：Debian/Ubuntu 用 `build-essential`，macOS 装 Xcode CLT，Fedora/Arch 用 `gcc`。 |
+| `tests/firmware/*.bin` 不存在 | 仓库自带预编译二进制。若被删掉，可在装好 `riscv64-elf-` 交叉工具链后执行 `cd tests/firmware && ./build.sh` 重建。 |
+| 冒烟命令卡住 | 检查参数是否漏了 `-bios none`。`sifive_pass.bin` 是裸金属内核，不带 `-bios none` 会被 RustSBI 接管而不退出。 |
+| `make test` 跑得很久 | 这是正常的——测试套件很大。日常迭代请用 `cargo test -p machina-tests <filter>` 跑窄测试，只在 push 之前跑一次 `make test`。 |
+| `info registers` 提示 "VM must be paused" | 当前虚拟机仍在运行。先发 `stop`（HMP）或 `{"execute":"stop"}`（QMP）暂停，再查询寄存器。 |
+
 ## 快速开始
 
 ### 构建


### PR DESCRIPTION
Resolves gevico/machina#63.

## What

The Quick Start sections in \`docs/{en,zh}/getting-started.md\`
only showed placeholder \`path/to/kernel.elf\` commands, so a
fresh contributor could not verify a build without first
sourcing or compiling a guest kernel.

Add a "First-time Contributor Walk-through" section above the
existing Quick Start in both the English and Chinese
getting-started docs. Every command can be run on a fresh clone
because the smoke step uses the bundled \`tests/firmware\`
binaries (\`sifive_pass.bin\`, \`sbi_smoke.bin\`).

### Walk-through

1. Host dependencies (Rust toolchain via rustup, make, host C linker).
2. \`make release\`.
3. Smoke-boot \`tests/firmware/sifive_pass.bin\` and verify the
   \`machina: shutdown (pass)\` output marker.
4. Optionally smoke-boot \`tests/firmware/sbi_smoke.bin\` to
   exercise the bundled RustSBI path; output begins with the
   RustSBI banner and ends with \`MACHINA_SBI_OK\`.
5. Narrow \`cargo test -p machina-tests <filter>\` examples for
   common areas (tools, disas, memory_region, riscv_csr).
6. Pre-PR checks: \`make fmt-check\`, \`make clippy\`, \`make test\`,
   plus \`make check-agent-skills\` when \`.agents/\` changed.
7. Troubleshooting table covering missing \`cc\`, missing firmware
   binaries, hangs from forgetting \`-bios none\`, slow
   \`make test\`, and the \`info registers\` pause gate.

### Verified output

The two bundled smoke commands were run against
\`./target/release/machina\` from a fresh build:

\`\`\`
$ ./target/release/machina -M riscv64-ref -m 128 -bios none \
    -kernel tests/firmware/sifive_pass.bin -nographic
machina: riscv64-ref, 128 MiB RAM
machina: entering execution loop
machina: shutdown (pass)
\`\`\`

The \`sbi_smoke.bin\` invocation prints the full RustSBI banner
(Hello RustSBI, version 0.4.0, ASCII logo, "Platform Name:
Machina RISC-V Reference Platform", PMP table, …) and exits
cleanly with \`MACHINA_SBI_OK\`.

### Bilingual parity

The English and Chinese sections carry the same structure,
expected-output snippets, and troubleshooting rows. Existing
Quick Start blocks below are left unchanged so the bilingual
docs stay in sync.

## Test plan

- [x] \`./target/release/machina ... sifive_pass.bin\` exits 0 with the documented marker.
- [x] \`./target/release/machina ... sbi_smoke.bin\` prints \`RustSBI\` banner + \`MACHINA_SBI_OK\` and exits 0.
- [x] Markdown is exempt from the 80-column rule (per AGENTS.md), no fmt change needed.