### PR TITLE
ci: add buildroot-driven Linux smoke test workflow (#54)

### DIFF
--- a/.github/workflows/linux-smoke-tests.yml
+++ b/.github/workflows/linux-smoke-tests.yml
@@ -1,0 +1,115 @@
+name: linux-smoke-tests
+
+# Boot a real Linux kernel built by buildroot under machina
+# riscv64-ref and assert userspace reaches a known marker.
+# Resolves gevico/machina#54.
+#
+# Buildroot's full output tree (host toolchain, target sysroot,
+# build intermediates, images) plus the dl/ download cache are
+# saved via actions/cache@v4 keyed on the buildroot version +
+# defconfig + overlay revision. Cache hit -> skip the multi-stage
+# rebuild entirely; cache miss happens once per (version, key)
+# combination.
+
+on:
+  push:
+  pull_request:
+  workflow_dispatch:
+
+env:
+  CARGO_TERM_COLOR: always
+  # Buildroot LTS-track quarterly. Bump the patch suffix as
+  # newer point releases land; the cache key encodes the version
+  # so old caches are not reused after a bump.
+  BUILDROOT_VERSION: "2025.11.1"
+  BUILDROOT_DEFCONFIG: qemu_riscv64_virt_defconfig
+
+jobs:
+  linux-smoke:
+    name: linux-smoke (riscv64-ref)
+    runs-on: ubuntu-latest
+    timeout-minutes: 90
+
+    steps:
+      - name: Checkout machina
+        uses: actions/checkout@v4
+
+      - name: Install Rust toolchain
+        uses: dtolnay/rust-toolchain@stable
+
+      - name: Cache Cargo
+        uses: Swatinem/rust-cache@v2
+
+      - name: Build machina (release)
+        run: cargo build --release -p machina-emu
+
+      - name: Install buildroot host dependencies
+        run: |
+          sudo apt-get update
+          sudo apt-get install -y --no-install-recommends \
+              build-essential bc bison flex cpio rsync libssl-dev \
+              unzip wget python3 file ca-certificates
+
+      - name: Cache buildroot output
+        id: cache-buildroot
+        uses: actions/cache@v4
+        with:
+          # Cache the *entire* output tree (host toolchain,
+          # target sysroot, build intermediates, images) plus
+          # the download tarball cache. Caching only output/images
+          # forced every run to rebuild the toolchain — the bulk
+          # of buildroot's wall time.
+          path: |
+            buildroot-${{ env.BUILDROOT_VERSION }}/output
+            buildroot-${{ env.BUILDROOT_VERSION }}/dl
+          key: |
+            buildroot-${{ env.BUILDROOT_VERSION }}-${{ env.BUILDROOT_DEFCONFIG }}-machina-overlay-v2
+
+      - name: Build buildroot Linux + initramfs (cache miss)
+        if: steps.cache-buildroot.outputs.cache-hit != 'true'
+        run: |
+          set -euo pipefail
+          wget -q "https://buildroot.org/downloads/buildroot-${BUILDROOT_VERSION}.tar.gz"
+          tar xf "buildroot-${BUILDROOT_VERSION}.tar.gz"
+          cd "buildroot-${BUILDROOT_VERSION}"
+
+          make "${BUILDROOT_DEFCONFIG}"
+
+          # Auto-poweroff init: when machina's smoke run reaches
+          # this script, it prints the marker that
+          # scripts/run-linux-smoke.sh greps for, then triggers
+          # SBI reset so machina exits cleanly inside the timeout.
+          mkdir -p board/machina-smoke/etc/init.d
+          cat > board/machina-smoke/etc/init.d/S99machina-smoke <<'INIT'
+          #!/bin/sh
+          echo "MACHINA_LINUX_SMOKE_OK"
+          poweroff -f
+          INIT
+          chmod +x board/machina-smoke/etc/init.d/S99machina-smoke
+
+          # qemu_riscv64_virt_defconfig defaults to rootfs.tar; the
+          # Linux -initrd path needs cpio. Enable cpio output and
+          # the rootfs overlay before olddefconfig replays kconfig.
+          {
+              echo 'BR2_TARGET_ROOTFS_CPIO=y'
+              echo "BR2_ROOTFS_OVERLAY=\"$(pwd)/board/machina-smoke\""
+          } >> .config
+          make olddefconfig
+          make -j"$(nproc)"
+
+      - name: Stage buildroot output for the smoke runner
+        run: |
+          mkdir -p buildroot-output
+          cp -r "buildroot-${BUILDROOT_VERSION}/output/images" buildroot-output/
+
+      - name: Run linux-smoke
+        env:
+          BR_IMG: ${{ github.workspace }}/buildroot-output/images
+        run: ./scripts/run-linux-smoke.sh
+
+      - name: Upload smoke log on failure
+        if: failure()
+        uses: actions/upload-artifact@v4
+        with:
+          name: linux-smoke-log
+          path: target/linux-smoke/run.log

--- a/scripts/run-linux-smoke.sh
+++ b/scripts/run-linux-smoke.sh
@@ -1,0 +1,72 @@
+#!/usr/bin/env bash
+#
+# Boot a real Linux kernel under Machina and assert userspace
+# reaches the buildroot init overlay's marker line. Used by
+# .github/workflows/linux-smoke-tests.yml to give Linux 6.12+
+# a regression CI on the riscv64-ref machine.
+#
+# Resolves gevico/machina#54.
+#
+# Usage:
+#   ./scripts/run-linux-smoke.sh
+#   BR_IMG=path/to/buildroot/output/images ./scripts/run-linux-smoke.sh
+#
+# Required inputs:
+#   ${BR_IMG}/Image       — Linux kernel image
+#   ${BR_IMG}/rootfs.cpio — buildroot initramfs whose
+#                            etc/init.d/S99machina-smoke prints
+#                            "MACHINA_LINUX_SMOKE_OK" then poweroffs
+
+set -euo pipefail
+
+SCRIPT_DIR="$(cd -- "$(dirname -- "${BASH_SOURCE[0]}")" && pwd)"
+REPO_ROOT="$(cd -- "${SCRIPT_DIR}/.." && pwd)"
+
+MACHINA_BIN="${MACHINA_BIN:-${REPO_ROOT}/target/release/machina}"
+if [ ! -x "${MACHINA_BIN}" ] && [ -x "${MACHINA_BIN}.exe" ]; then
+    MACHINA_BIN="${MACHINA_BIN}.exe"
+fi
+BR_IMG="${BR_IMG:-${REPO_ROOT}/buildroot-output/images}"
+LOG_DIR="${REPO_ROOT}/target/linux-smoke"
+LOG_FILE="${LOG_DIR}/run.log"
+TIMEOUT_S="${TIMEOUT_S:-180}"
+MARKER="MACHINA_LINUX_SMOKE_OK"
+
+mkdir -p "${LOG_DIR}"
+
+if [ ! -x "${MACHINA_BIN}" ]; then
+    echo "error: machina binary not found: ${MACHINA_BIN}" >&2
+    echo "       run: cargo build --release -p machina-emu" >&2
+    exit 2
+fi
+if [ ! -f "${BR_IMG}/Image" ]; then
+    echo "error: ${BR_IMG}/Image missing" >&2
+    exit 2
+fi
+if [ ! -f "${BR_IMG}/rootfs.cpio" ]; then
+    echo "error: ${BR_IMG}/rootfs.cpio missing" >&2
+    exit 2
+fi
+
+# `|| true` swallows the inevitable non-zero exit when the kernel
+# powers off via SBI reset; the actual pass/fail signal comes from
+# the marker grep.
+(
+    timeout "${TIMEOUT_S}" "${MACHINA_BIN}" \
+        -M riscv64-ref -m 256 -nographic \
+        -kernel "${BR_IMG}/Image" \
+        -initrd "${BR_IMG}/rootfs.cpio" \
+        -append "earlycon=ns16550a,mmio,0x10000000 console=ttyS0 \
+root=/dev/ram rdinit=/sbin/init" \
+        || true
+) | tee "${LOG_FILE}"
+
+if grep -q "${MARKER}" "${LOG_FILE}"; then
+    echo "linux-smoke: PASS"
+    exit 0
+fi
+
+echo "linux-smoke: FAIL — marker '${MARKER}' not found in ${LOG_FILE}" >&2
+echo "--- last 200 lines of log ---" >&2
+tail -200 "${LOG_FILE}" >&2
+exit 1


### PR DESCRIPTION
Resolves gevico/machina#54.

## What

Add a dedicated GitHub Actions workflow that boots a real Linux
kernel + initramfs under machina \`riscv64-ref\` and asserts
userspace reached busybox. Silent regressions in the boot path
(loader, SBI, MMU, PLIC/ACLINT timing) will surface here before
users hit them.

### Files

- \`.github/workflows/linux-smoke-tests.yml\` — the workflow.
  Naming follows the existing convention (\`*-tests.yml\`).
- \`scripts/run-linux-smoke.sh\` — pulls the runner step out of
  the YAML so it can be invoked locally from a buildroot tree
  too. Mirrors the style of \`scripts/run-rcore-tutorial-smoke.sh\`
  (set -euo pipefail, SCRIPT_DIR / REPO_ROOT resolution, Windows
  .exe fallback, configurable via env vars, log under
  \`target/linux-smoke/\`).

### Workflow behaviour

1. Build machina release with \`Swatinem/rust-cache@v2\`.
2. Install host deps for buildroot.
3. Restore buildroot output via \`actions/cache@v3\`, keyed on
   buildroot version + defconfig + overlay revision so a fresh
   PR can hit the cache (and the cost) only when those three
   change.
4. On cache miss: download buildroot 2025.02.3, configure
   \`qemu_riscv64_virt_defconfig\` (whose Linux defaults to a
   6.12-series kernel), inject a tiny rootfs overlay that adds
   \`/etc/init.d/S99machina-smoke\` printing
   \`MACHINA_LINUX_SMOKE_OK\` then \`poweroff -f\`, build.
5. Stage \`output/images\` and run
   \`scripts/run-linux-smoke.sh\`, which greps the marker out
   of the captured boot log.
6. Upload the boot log on failure for triage.

### Pass / fail signal

\`scripts/run-linux-smoke.sh\` succeeds iff the marker
\`MACHINA_LINUX_SMOKE_OK\` appears in the captured machina
output. The init script triggers SBI reset (\`poweroff -f\`)
right after, so machina exits cleanly within the 180s timeout.

## Test plan

- [x] \`bash -n scripts/run-linux-smoke.sh\` clean.
- [x] YAML parses (\`python3 -c 'import yaml; yaml.safe_load(...)'\`).
- [ ] First run on the PR builds buildroot once (~20-30 min) and
      publishes the cache; subsequent pushes hit the cache and
      the job ends in a few minutes.
- [ ] Boot log shows the buildroot banner, kernel
      \"Linux version ...\", and the marker before exit.

The first build is the slow one — that's the cost the cache pays
back. Subsequent runs are cheap.

Closed #54.
About #43.