### PR TITLE
feat(monitor): implement MMP system_powerdown (#88)

### DIFF
--- a/monitor/src/mmp.rs
+++ b/monitor/src/mmp.rs
@@ -130,6 +130,10 @@ pub fn dispatch(cmd: &str, svc: &Arc<Mutex<MonitorService>>) -> Value {
             s.quit();
             json!({"return": {}})
         }
+        "system_powerdown" => {
+            s.quit();
+            json!({"return": {}})
+        }
         "query-cpus-fast" => {
             let cpus = s.query_cpus();
             let arr: Vec<Value> = cpus

--- a/tests/src/monitor.rs
+++ b/tests/src/monitor.rs
@@ -137,6 +137,14 @@ fn test_mmp_quit() {
     assert!(svc.lock().unwrap().state.is_quit_requested());
 }
 
+#[test]
+fn test_mmp_system_powerdown() {
+    let svc = make_svc();
+    let resp = mmp::dispatch("system_powerdown", &svc);
+    assert_eq!(resp["return"], serde_json::json!({}));
+    assert!(svc.lock().unwrap().state.is_quit_requested());
+}
+
 // ── HMP tests ───────────────────────────────────────
 
 #[test]


### PR DESCRIPTION
Closes #88.

Adds the `system_powerdown` MMP command. As noted in the issue, the existing `MonitorService::quit()` already does the right thing, so this mirrors the `quit` branch and adds a regression test alongside `test_mmp_quit`.
