### PR TITLE
ci: emit linux-smoke marker before network startup

### DIFF
--- a/.github/workflows/linux-smoke-tests.yml
+++ b/.github/workflows/linux-smoke-tests.yml
@@ -63,7 +63,7 @@ jobs:
             buildroot-${{ env.BUILDROOT_VERSION }}/output
             buildroot-${{ env.BUILDROOT_VERSION }}/dl
           key: |
-            buildroot-${{ env.BUILDROOT_VERSION }}-${{ env.BUILDROOT_DEFCONFIG }}-machina-overlay-v2
+            buildroot-${{ env.BUILDROOT_VERSION }}-${{ env.BUILDROOT_DEFCONFIG }}-machina-overlay-v3
 
       - name: Build buildroot Linux + initramfs (cache miss)
         if: steps.cache-buildroot.outputs.cache-hit != 'true'
@@ -76,16 +76,21 @@ jobs:
           make "${BUILDROOT_DEFCONFIG}"
 
           # Auto-poweroff init: when machina's smoke run reaches
-          # this script, it prints the marker that
+          # this script it prints the marker that
           # scripts/run-linux-smoke.sh greps for, then triggers
           # SBI reset so machina exits cleanly inside the timeout.
+          # Numbered S39 so it runs before S40network: riscv64-ref
+          # only exposes a NIC with -netdev, which this run omits,
+          # so the default eth0 bring-up would otherwise block on
+          # "Waiting for interface eth0 to appear" until the run
+          # times out and the marker would never print.
           mkdir -p board/machina-smoke/etc/init.d
-          cat > board/machina-smoke/etc/init.d/S99machina-smoke <<'INIT'
+          cat > board/machina-smoke/etc/init.d/S39machina-smoke <<'INIT'
           #!/bin/sh
           echo "MACHINA_LINUX_SMOKE_OK"
           poweroff -f
           INIT
-          chmod +x board/machina-smoke/etc/init.d/S99machina-smoke
+          chmod +x board/machina-smoke/etc/init.d/S39machina-smoke
 
           # qemu_riscv64_virt_defconfig defaults to rootfs.tar; the
           # Linux -initrd path needs cpio. Enable cpio output and

--- a/scripts/run-linux-smoke.sh
+++ b/scripts/run-linux-smoke.sh
@@ -14,7 +14,7 @@
 # Required inputs:
 #   ${BR_IMG}/Image       — Linux kernel image
 #   ${BR_IMG}/rootfs.cpio — buildroot initramfs whose
-#                            etc/init.d/S99machina-smoke prints
+#                            etc/init.d/S39machina-smoke prints
 #                            "MACHINA_LINUX_SMOKE_OK" then poweroffs
 
 set -euo pipefail


### PR DESCRIPTION
## Problem

The `linux-smoke (riscv64-ref)` job (added in #54) is flaky and has
started failing on open PRs. The kernel boots fine, but the run hangs
in userspace at:

```
Starting network: Waiting for interface eth0 to appear
```

until the 180s run timeout kills machina, so `MACHINA_LINUX_SMOKE_OK`
is never printed.

## Root cause

`riscv64-ref` attaches a VirtIO NIC only when `-netdev` is passed
(`hw/riscv/src/ref_machine.rs`), and the smoke command line omits it —
so the guest has no `eth0`. The buildroot rootfs
(`qemu_riscv64_virt_defconfig`) nevertheless auto-runs `S40network`,
which blocks waiting for an interface that can never appear. The
marker script ran last (`S99machina-smoke`), *after* networking, so it
was never reached. Whether the eth0 wait gave up before the 180s
timeout depended on runner speed, which is why the job passed on the
initial `main` push and fails on slower PR runners.

## Fix

- Rename the overlay marker init script `S99machina-smoke` →
  `S39machina-smoke` so it prints the marker and powers off **before**
  `S40network` runs. The smoke result no longer depends on networking,
  which is irrelevant on a machine with no NIC.
- Bump the buildroot cache key `…-machina-overlay-v2` → `v3` so the
  rebuilt overlay is used instead of a cache hit that still carries the
  old `S99` script.

Reaching `S39` still proves the kernel boots through initramfs into
userspace init (syslogd/klogd/sysctl all run first), so the smoke
signal is preserved.

Refs #54.
