### PR TITLE
hw/riscv: model the k230 kpu as an mmio device

### DIFF
--- a/hw/riscv/src/k230.rs
+++ b/hw/riscv/src/k230.rs
@@ -31,6 +31,7 @@ use machina_memory::region::MemoryRegion;
 use crate::k230_gzip_dma::{
     K230GzipDma, K230GzipDmaMmio, K230_GZIP_DMA_MMIO_SIZE,
 };
+use crate::k230_kpu::{K230Kpu, K230KpuCfgMmio, K230KpuL2Mmio};
 use crate::k230_pufs::{K230Pufs, K230PufsMmio, K230_PUFS_MMIO_SIZE};
 
 #[derive(Clone, Copy)]
@@ -412,6 +413,7 @@ pub struct K230Machine {
     sdhcis: Vec<Arc<Sdhci>>,
     gzip_dma: Option<Arc<K230GzipDma>>,
     pufs: Option<Arc<K230Pufs>>,
+    kpu: Option<Arc<K230Kpu>>,
     unimp: Vec<Arc<Unimp>>,
     pub(crate) cpus: Arc<Mutex<Vec<Option<RiscvCpu>>>>,
     pub(crate) shared_mip: Arc<AtomicU64>,
@@ -450,6 +452,7 @@ impl K230Machine {
             sdhcis: Vec::new(),
             gzip_dma: None,
             pufs: None,
+            kpu: None,
             unimp: Vec::new(),
             cpus: Arc::new(Mutex::new(Vec::new())),
             shared_mip: Arc::new(AtomicU64::new(0)),
@@ -660,6 +663,9 @@ impl K230Machine {
         if let Some(pufs) = &self.pufs {
             Self::track_mom_info(&mut tree, pufs.object_info());
         }
+        if let Some(kpu) = &self.kpu {
+            Self::track_mom_info(&mut tree, kpu.object_info());
+        }
         for dev in &self.unimp {
             Self::track_mom_info(
                 &mut tree,
@@ -720,6 +726,28 @@ impl K230Machine {
             Arc::new(K230PufsMmio(Arc::clone(&dev))),
         );
         dev.register_mmio(region, GPA::new(entry.base))?;
+        Ok(dev)
+    }
+
+    fn map_kpu(
+        sysbus: &mut SysBus,
+    ) -> Result<Arc<K230Kpu>, Box<dyn std::error::Error>> {
+        let dev = K230Kpu::new_named("k230-kpu");
+        dev.attach_to_bus(sysbus)?;
+        let cfg = K230_MEMMAP[K230MemMap::KpuCfg as usize];
+        let cfg_region = MemoryRegion::io(
+            "k230-kpu-cfg",
+            cfg.size,
+            Arc::new(K230KpuCfgMmio(Arc::clone(&dev))),
+        );
+        dev.register_mmio(cfg_region, GPA::new(cfg.base))?;
+        let l2 = K230_MEMMAP[K230MemMap::KpuL2Cache as usize];
+        let l2_region = MemoryRegion::io(
+            "k230-kpu-l2-cache",
+            l2.size,
+            Arc::new(K230KpuL2Mmio(Arc::clone(&dev))),
+        );
+        dev.register_mmio(l2_region, GPA::new(l2.base))?;
         Ok(dev)
     }
 
@@ -818,8 +846,6 @@ impl K230Machine {
 
     fn unimp_specs() -> &'static [(K230MemMap, &'static str)] {
         &[
-            (K230MemMap::KpuL2Cache, "kpu.l2-cache"),
-            (K230MemMap::KpuCfg, "kpu_cfg"),
             (K230MemMap::Fft, "fft"),
             (K230MemMap::Ai2d, "2d-engine.ai"),
             (K230MemMap::NonAi2d, "2d-engine.non-ai"),
@@ -1024,6 +1050,7 @@ impl Machine for K230Machine {
 
         let gzip_dma = Self::map_gzip_dma(&mut sysbus)?;
         let pufs = Self::map_pufs(&mut sysbus)?;
+        let kpu = Self::map_kpu(&mut sysbus)?;
 
         let mut unimp = Vec::with_capacity(Self::unimp_specs().len());
         for &(map, name) in Self::unimp_specs() {
@@ -1073,6 +1100,7 @@ impl Machine for K230Machine {
             }
             gzip_dma.realize_onto(&mut sysbus, address_space)?;
             pufs.realize_onto(&mut sysbus, address_space)?;
+            kpu.realize_onto(&mut sysbus, address_space)?;
             for dev in &unimp {
                 dev.realize_onto(&mut sysbus, address_space)?;
             }
@@ -1095,6 +1123,7 @@ impl Machine for K230Machine {
         self.sdhcis = sdhcis;
         self.gzip_dma = Some(gzip_dma);
         self.pufs = Some(pufs);
+        self.kpu = Some(kpu);
         self.unimp = unimp;
         self.sysbus = Some(sysbus);
         self.refresh_mom_tree();
@@ -1123,6 +1152,9 @@ impl Machine for K230Machine {
         }
         if let Some(pufs) = &self.pufs {
             pufs.reset_runtime();
+        }
+        if let Some(kpu) = &self.kpu {
+            kpu.reset_runtime();
         }
         for dev in &self.unimp {
             dev.reset_runtime();

--- a/hw/riscv/src/k230_kpu.rs
+++ b/hw/riscv/src/k230_kpu.rs
@@ -1,0 +1,135 @@
+//! Minimal K230 KPU (Knowledge Process Unit) device model.
+//!
+//! The K230 KPU is Canaan's AI/NPU inference accelerator. Its
+//! register/command interface is undocumented and driven by the
+//! closed-source `nncase` runtime, so mainline QEMU models the two KPU
+//! windows as `create_unimplemented_device` stubs ("kpu.l2-cache" and
+//! "kpu_cfg"). This model promotes them to a real SysBus device:
+//!
+//! - The CFG window (`0x8040_0000`, 2 KiB) is modelled as a plain
+//!   scratch register file: written values are retained and read back,
+//!   with no invented per-register semantics.
+//! - The L2-cache window (`0x8000_0000`, 2 MiB) is a read-as-zero,
+//!   writes-ignored stub, matching QEMU's unimplemented-device.
+//!
+//! No KPU register offsets, IRQ, or DMA behaviour is invented here; the
+//! real command/descriptor format is sealed inside `nncase`.
+
+use std::sync::Arc;
+
+use machina_core::device_cell::DeviceRegs;
+use machina_hw_core::bus::SysBusDeviceState;
+use machina_memory::region::MmioOps;
+
+/// Size of the KPU CFG register window (matches `K230MemMap::KpuCfg`).
+pub const K230_KPU_CFG_MMIO_SIZE: u64 = 0x0000_0800;
+
+struct K230KpuRegs {
+    cfg: [u8; K230_KPU_CFG_MMIO_SIZE as usize],
+}
+
+impl Default for K230KpuRegs {
+    fn default() -> Self {
+        Self {
+            cfg: [0; K230_KPU_CFG_MMIO_SIZE as usize],
+        }
+    }
+}
+
+#[derive(machina_hw_core::SysBusDevice)]
+#[mom(state = state, lock = "std")]
+pub struct K230Kpu {
+    state: std::sync::Mutex<SysBusDeviceState>,
+    regs: DeviceRegs<K230KpuRegs>,
+}
+
+impl K230Kpu {
+    #[must_use]
+    pub fn new_named(local_id: &str) -> Arc<Self> {
+        Arc::new(Self {
+            state: std::sync::Mutex::new(SysBusDeviceState::new(local_id)),
+            regs: DeviceRegs::new(K230KpuRegs::default()),
+        })
+    }
+
+    pub fn reset_runtime(&self) {
+        *self.regs.lock() = K230KpuRegs::default();
+    }
+
+    /// CFG window: a scratch register file. Written values are retained
+    /// and read back; locations never written read back as zero.
+    fn read_cfg(&self, offset: u64, size: u32) -> u64 {
+        if !valid_mmio_access(offset, size) {
+            return 0;
+        }
+        let regs = self.regs.lock();
+        read_bytes_le(&regs.cfg, offset, size)
+    }
+
+    fn write_cfg(&self, offset: u64, size: u32, value: u64) {
+        if !valid_mmio_access(offset, size) {
+            return;
+        }
+        let mut regs = self.regs.lock();
+        write_bytes_le(&mut regs.cfg, offset, size, value);
+    }
+
+    /// L2-cache window: a faithful unimplemented-device stub. Reads
+    /// return zero and writes are dropped, matching mainline QEMU.
+    fn read_l2(&self, _offset: u64, _size: u32) -> u64 {
+        0
+    }
+
+    fn write_l2(&self, _offset: u64, _size: u32, _value: u64) {}
+}
+
+pub struct K230KpuCfgMmio(pub Arc<K230Kpu>);
+
+impl MmioOps for K230KpuCfgMmio {
+    fn read(&self, offset: u64, size: u32) -> u64 {
+        self.0.read_cfg(offset, size)
+    }
+
+    fn write(&self, offset: u64, size: u32, value: u64) {
+        self.0.write_cfg(offset, size, value);
+    }
+}
+
+pub struct K230KpuL2Mmio(pub Arc<K230Kpu>);
+
+impl MmioOps for K230KpuL2Mmio {
+    fn read(&self, offset: u64, size: u32) -> u64 {
+        self.0.read_l2(offset, size)
+    }
+
+    fn write(&self, offset: u64, size: u32, value: u64) {
+        self.0.write_l2(offset, size, value);
+    }
+}
+
+fn valid_mmio_access(offset: u64, size: u32) -> bool {
+    matches!(size, 1 | 2 | 4 | 8) && offset.is_multiple_of(u64::from(size))
+}
+
+fn read_bytes_le(bytes: &[u8], offset: u64, size: u32) -> u64 {
+    let index = offset as usize;
+    let len = size as usize;
+    if index + len > bytes.len() {
+        return 0;
+    }
+    let mut value = 0;
+    for (shift, byte) in bytes[index..index + len].iter().copied().enumerate() {
+        value |= u64::from(byte) << (shift * 8);
+    }
+    value
+}
+
+fn write_bytes_le(bytes: &mut [u8], offset: u64, size: u32, value: u64) {
+    let index = offset as usize;
+    let len = size as usize;
+    if index + len > bytes.len() {
+        return;
+    }
+    let encoded = value.to_le_bytes();
+    bytes[index..index + len].copy_from_slice(&encoded[..len]);
+}

--- a/hw/riscv/src/lib.rs
+++ b/hw/riscv/src/lib.rs
@@ -3,6 +3,7 @@ pub mod k230;
 pub mod k230_boot;
 pub mod k230_dtb;
 pub mod k230_gzip_dma;
+pub mod k230_kpu;
 pub mod k230_pufs;
 pub mod ref_machine;
 pub mod sbi;

--- a/tests/src/hw_k230_kpu.rs
+++ b/tests/src/hw_k230_kpu.rs
@@ -1,0 +1,135 @@
+//! Regression tests for the K230 KPU device model (#157).
+//!
+//! Mainline QEMU models the two KPU windows as `unimplemented_device`
+//! stubs; machina promotes them to a real SysBus device. The CFG window
+//! is a scratch register file (writes retained, read back); the L2-cache
+//! window is a read-as-zero, writes-ignored stub. These tests pin that
+//! behaviour, the access-width handling, reset, and the device lifecycle
+//! driven through an `AddressSpace` at the real K230 GPAs.
+
+use std::sync::Arc;
+
+use machina_core::address::GPA;
+use machina_hw_core::bus::SysBus;
+use machina_hw_riscv::k230_kpu::{
+    K230Kpu, K230KpuCfgMmio, K230KpuL2Mmio, K230_KPU_CFG_MMIO_SIZE,
+};
+use machina_memory::address_space::AddressSpace;
+use machina_memory::region::{MemoryRegion, MmioOps};
+
+const KPU_CFG_BASE: u64 = 0x8040_0000;
+const KPU_L2_BASE: u64 = 0x8000_0000;
+const KPU_L2_SIZE: u64 = 0x0020_0000;
+
+fn make_test_aspace() -> (AddressSpace, SysBus) {
+    let root = MemoryRegion::container("root", 0x1_0000_0000);
+    let aspace = AddressSpace::new(root);
+    let bus = SysBus::new("sysbus");
+    (aspace, bus)
+}
+
+#[test]
+fn cfg_window_retains_writes() {
+    let kpu = K230Kpu::new_named("k230-kpu");
+    let cfg = K230KpuCfgMmio(Arc::clone(&kpu));
+
+    cfg.write(0x10, 4, 0xdead_beef);
+    assert_eq!(cfg.read(0x10, 4), 0xdead_beef);
+
+    // Little-endian sub-word reads of the stored word.
+    assert_eq!(cfg.read(0x10, 1), 0xef);
+    assert_eq!(cfg.read(0x12, 2), 0xdead);
+
+    // A location that was never written reads back as zero.
+    assert_eq!(cfg.read(0x40, 4), 0);
+}
+
+#[test]
+fn cfg_window_rejects_unaligned_and_oob() {
+    let kpu = K230Kpu::new_named("k230-kpu");
+    let cfg = K230KpuCfgMmio(Arc::clone(&kpu));
+
+    // Unaligned accesses are ignored: the write is dropped and the read
+    // returns zero rather than a partial value.
+    cfg.write(0x11, 4, 0xaaaa_aaaa);
+    assert_eq!(cfg.read(0x11, 4), 0);
+    assert_eq!(cfg.read(0x10, 4), 0);
+
+    // The last aligned word of the 2 KiB window is addressable...
+    let last = K230_KPU_CFG_MMIO_SIZE - 4;
+    cfg.write(last, 4, 0x1234_5678);
+    assert_eq!(cfg.read(last, 4), 0x1234_5678);
+
+    // ...but an access running past the end of the window is dropped.
+    assert_eq!(cfg.read(K230_KPU_CFG_MMIO_SIZE, 4), 0);
+}
+
+#[test]
+fn l2_window_is_zero_stub() {
+    let kpu = K230Kpu::new_named("k230-kpu");
+    let l2 = K230KpuL2Mmio(Arc::clone(&kpu));
+
+    // Writes are dropped and reads always return zero, mirroring QEMU's
+    // unimplemented-device behaviour for "kpu.l2-cache".
+    l2.write(0x0, 4, 0xffff_ffff);
+    l2.write(0x1_0000, 8, 0xdead_beef_dead_beef);
+    assert_eq!(l2.read(0x0, 4), 0);
+    assert_eq!(l2.read(0x1_0000, 8), 0);
+}
+
+#[test]
+fn reset_clears_cfg_scratch() {
+    let kpu = K230Kpu::new_named("k230-kpu");
+    let cfg = K230KpuCfgMmio(Arc::clone(&kpu));
+
+    cfg.write(0x20, 4, 0xcafe_f00d);
+    assert_eq!(cfg.read(0x20, 4), 0xcafe_f00d);
+
+    kpu.reset_runtime();
+    assert_eq!(cfg.read(0x20, 4), 0);
+}
+
+#[test]
+fn lifecycle_maps_both_windows_and_mom_identity() {
+    let kpu = K230Kpu::new_named("k230-kpu");
+    assert!(!kpu.realized());
+    kpu.with_mdevice(|device| assert_eq!(device.local_id(), "k230-kpu"));
+    assert_eq!(kpu.object_info().local_id, "k230-kpu");
+
+    let (mut aspace, mut bus) = make_test_aspace();
+    kpu.attach_to_bus(&mut bus).unwrap();
+    kpu.register_mmio(
+        MemoryRegion::io(
+            "k230-kpu-cfg",
+            K230_KPU_CFG_MMIO_SIZE,
+            Arc::new(K230KpuCfgMmio(Arc::clone(&kpu))),
+        ),
+        GPA(KPU_CFG_BASE),
+    )
+    .unwrap();
+    kpu.register_mmio(
+        MemoryRegion::io(
+            "k230-kpu-l2-cache",
+            KPU_L2_SIZE,
+            Arc::new(K230KpuL2Mmio(Arc::clone(&kpu))),
+        ),
+        GPA(KPU_L2_BASE),
+    )
+    .unwrap();
+    kpu.realize_onto(&mut bus, &mut aspace).unwrap();
+    assert!(kpu.realized());
+
+    // CFG window retains writes through the address space...
+    aspace.write(GPA(KPU_CFG_BASE + 0x20), 4, 0x1234);
+    assert_eq!(aspace.read(GPA(KPU_CFG_BASE + 0x20), 4), 0x1234);
+    // ...and the L2 window always reads back as zero.
+    aspace.write(GPA(KPU_L2_BASE), 4, 0xffff_ffff);
+    assert_eq!(aspace.read(GPA(KPU_L2_BASE), 4), 0);
+
+    let err = kpu.realize_onto(&mut bus, &mut aspace).unwrap_err();
+    assert!(err.to_string().contains("already realized"));
+
+    kpu.unrealize_from(&mut bus, &mut aspace).unwrap();
+    assert!(!kpu.realized());
+    assert_eq!(aspace.read(GPA(KPU_CFG_BASE + 0x20), 4), 0);
+}

--- a/tests/src/hw_k230_machine.rs
+++ b/tests/src/hw_k230_machine.rs
@@ -58,7 +58,8 @@ fn k230_machine_maps_real_devices_and_unimp_windows() {
     assert!(sysbus.mappings().iter().any(|m| m.owner == "uart4"));
     assert!(sysbus.mappings().iter().any(|m| m.owner == "k230-wdt0"));
     assert!(sysbus.mappings().iter().any(|m| m.owner == "k230-wdt1"));
-    assert!(sysbus.mappings().iter().any(|m| m.owner == "kpu.l2-cache"));
+    // The KPU is now a real device (k230-kpu), not an unimp window.
+    assert!(sysbus.mappings().iter().any(|m| m.owner == "k230-kpu"));
     assert!(machine.wdt(K230WdtIndex::Wdt0).is_some());
     assert!(machine.wdt(K230WdtIndex::Wdt1).is_some());
 }

--- a/tests/src/lib.rs
+++ b/tests/src/lib.rs
@@ -65,6 +65,8 @@ mod hw_irq;
 #[cfg(test)]
 mod hw_k230_gzip_dma;
 #[cfg(test)]
+mod hw_k230_kpu;
+#[cfg(test)]
 mod hw_k230_machine;
 #[cfg(test)]
 mod hw_k230_pufs;


### PR DESCRIPTION
## Summary

Promotes the K230 KPU from two `create_unimplemented_device`-style
`unimp` windows to a real `K230Kpu` SysBus device, as tracked in #157.

Mainline QEMU's K230 board (`hw/riscv/k230.c`) models the KPU only as
unimplemented-device stubs ("kpu.l2-cache" @ `0x8000_0000`, "kpu_cfg" @
`0x8040_0000`), and machina mirrored that in `unimp_specs()`. The KPU's
register/command interface is undocumented (driven by the closed-source
`nncase` runtime), so a functional NPU model is out of scope; this gives
machina a real device object with MOM identity, lifecycle, and reset.

## Changes

- `hw/riscv/src/k230_kpu.rs` (new): the `K230Kpu` device.
  - **CFG** window (`0x8040_0000`, 2 KiB): scratch register file — writes
    are retained and read back little-endian, with no invented
    per-register semantics.
  - **L2 cache** window (`0x8000_0000`, 2 MiB): read-as-zero,
    writes-ignored stub, matching QEMU's unimplemented-device (no 2 MiB
    backing is allocated).
- `hw/riscv/src/k230.rs`: wire `K230Kpu` into `K230Machine`
  (`attach_to_bus` → `register_mmio` for both windows → `realize_onto`),
  track it in the MOM tree and reset path, and remove the two KPU entries
  from `unimp_specs()`.
- `tests/src/hw_k230_kpu.rs` (new): CFG scratch read/write, access-width
  and bounds handling, the L2 zero stub, reset, and the full device
  lifecycle driven through an `AddressSpace` at the real K230 GPAs.
- `tests/src/hw_k230_machine.rs`: expect the real `k230-kpu` mapping in
  place of the removed `kpu.l2-cache` unimp window.

No IRQ is wired: the KPU's PLIC source number is not documented in QEMU,
the vendor DTS, or the public datasheet.

## Test plan

- [x] `cargo fmt --all -- --check`
- [x] `cargo build -p machina-emu`
- [x] `cargo clippy -p machina-hw-riscv -p machina-tests -- -D warnings -A clippy::pedantic -A clippy::nursery`
- [x] `cargo test -p machina-tests hw_k230` — 31 passed (incl. 5 new KPU tests)
- [x] Full `cargo test -p machina-tests` — only pre-existing `oracle::*`
  failures remain, verified identical on clean `upstream/main` and
  unrelated to this change.

Closes #157.
