### PR TITLE
tests: cover loongarch gcsrxchg guest-csr masking

### DIFF
--- a/tests/src/loongarch_priv.rs
+++ b/tests/src/loongarch_priv.rs
@@ -1319,6 +1319,40 @@ fn translated_gcsrwr_and_gcsrrd_access_guest_csr_state() {
 }
 
 #[test]
+fn translated_gcsrxchg_masks_guest_csr_state() {
+    // GCSRXCHG (rj >= 2) is the masked read-modify-write form of the
+    // guest-CSR accessors: rd supplies the new bits and receives the
+    // old value, while rj selects which bits actually change.
+    let mut cpu = LoongArchCpu::new();
+    cpu.gcsr_write(CSR_EENTRY, 0x9000_0000);
+    cpu.write_gpr(6, 0x1000_0000); // rj: mask selects bit 28 only
+    cpu.write_gpr(7, 0x2000_0000); // rd: candidate new value bits
+
+    assert_eq!(run_priv_la(&mut cpu, &[gcsr_insn(CSR_EENTRY, 6, 7)]), 0);
+
+    // rd receives the old CSR value.
+    assert_eq!(cpu.read_gpr(7), 0x9000_0000);
+    // Only the masked bit 28 changes (cleared, since rd's bit 28 is 0);
+    // bit 31 is preserved and rd's unmasked bit 29 is ignored.
+    assert_eq!(cpu.gcsr_read(CSR_EENTRY), 0x8000_0000);
+}
+
+#[test]
+fn translated_gcsrxchg_with_zero_mask_only_reads() {
+    // A zero mask must leave the guest CSR untouched while still
+    // returning the old value into rd.
+    let mut cpu = LoongArchCpu::new();
+    cpu.gcsr_write(CSR_EENTRY, 0x9000_0000);
+    cpu.write_gpr(6, 0); // rj: empty mask
+    cpu.write_gpr(7, 0x2000_0000);
+
+    assert_eq!(run_priv_la(&mut cpu, &[gcsr_insn(CSR_EENTRY, 6, 7)]), 0);
+
+    assert_eq!(cpu.read_gpr(7), 0x9000_0000);
+    assert_eq!(cpu.gcsr_read(CSR_EENTRY), 0x9000_0000);
+}
+
+#[test]
 fn translated_hvcl_raises_hvc_exception() {
     let mut cpu = LoongArchCpu::new();
     cpu.csr_write(CSR_EENTRY, 0x9000_0000);


### PR DESCRIPTION
## Summary

Adds regression coverage for the **GCSRXCHG** instruction, part of the
LoongArch LVZ guest-CSR surface tracked in #151.

The existing `translated_gcsrwr_and_gcsrrd_access_guest_csr_state` test
covers the `GCSRRD` (`rj=0`) and `GCSRWR` (`rj=1`) forms of the guest-CSR
accessor, but the masked read-modify-write form **`GCSRXCHG` (`rj>=2`)**
— backed by `LoongArchCpu::gcsr_xchg` and `loongarch_helper_gcsrxchg` —
had no coverage.

## Changes

- `tests/src/loongarch_priv.rs`: two new tests, placed next to the
  existing GCSRRD/GCSRWR test so they reuse the in-file translate harness
  (`gcsr_insn` / `run_priv_la`):
  - `translated_gcsrxchg_masks_guest_csr_state` — a non-zero mask updates
    only the selected guest-CSR bits (write-mask ∩ rj), preserves the
    unmasked bits, and writes the old value back into `rd`.
  - `translated_gcsrxchg_with_zero_mask_only_reads` — a zero mask leaves
    the guest CSR untouched while still returning the old value into `rd`.

## Notes

The LVZ implementation itself already exists in `upstream/main`; this PR
only closes a gap in its instruction-level test coverage. Part of #151.

## Test plan

- [x] `cargo fmt --all -- --check`
- [x] `cargo clippy -p machina-tests -- -D warnings -A clippy::pedantic -A clippy::nursery`
- [x] `cargo test -p machina-tests loongarch_priv` — 197 passed (incl. the
  2 new tests)
