### PR TITLE
ci: build rcore-smoke msys2 toolchain from UCRT64. You need to merge this first.

### DIFF
--- a/.github/workflows/tg-rcore-tutorial-tests.yml
+++ b/.github/workflows/tg-rcore-tutorial-tests.yml
@@ -44,12 +44,17 @@ jobs:
         if: matrix.name == 'msys2'
         uses: msys2/setup-msys2@v2
         with:
-          msystem: MINGW64
+          # UCRT64: MSYS2 dropped the legacy MINGW64 (msvcrt) build of the
+          # riscv64-unknown-elf cross-gcc, so the old
+          # mingw-w64-x86_64-riscv64-unknown-elf-gcc package no longer
+          # resolves. The UCRT64 variant ships the same
+          # riscv64-unknown-elf-gcc used here only as the RISC-V linker.
+          msystem: UCRT64
           update: true
           path-type: inherit
           cache: true
           install: >-
-            mingw-w64-x86_64-riscv64-unknown-elf-gcc
+            mingw-w64-ucrt-x86_64-riscv64-unknown-elf-gcc
 
       # Write cargo config before any cargo commands:
       # - check-revoke = false  avoids CRYPT_E_REVOCATION_OFFLINE errors


### PR DESCRIPTION
## Summary

`smoke (msys2)` (the `rcore-tutorial-smoke` workflow) has been failing on
every branch with:

```
error: target not found: mingw-w64-x86_64-riscv64-unknown-elf-gcc
```

## Cause

MSYS2 dropped the legacy **MINGW64 (msvcrt)** build of the
`riscv64-unknown-elf` cross-gcc. Only the **UCRT64**
(`mingw-w64-ucrt-x86_64-riscv64-unknown-elf-gcc`) and CLANG64 variants
remain (both 16.1.0). The job used `msystem: MINGW64` +
`mingw-w64-x86_64-riscv64-unknown-elf-gcc`, which pacman can no longer
resolve.

## Fix

Switch the rcore-smoke msys2 setup to `msystem: UCRT64` and install
`mingw-w64-ucrt-x86_64-riscv64-unknown-elf-gcc`. The UCRT64 package ships
the same `riscv64-unknown-elf-gcc` binary (used here only as the RISC-V
linker for `riscv64gc-unknown-none-elf`), so no other step changes.

The `MINGW64` usage in `check.yml` / `machina-tests.yml` is left as-is:
those jobs don't install the dropped cross-toolchain and pass fine.

## Validation

msys2 can't be run locally, so this is validated by the MSYS2 package
database (the UCRT64 package exists at 16.1.0 and provides
`riscv64-unknown-elf-gcc.exe`); the CI run on this PR confirms the
end-to-end fix.
